### PR TITLE
Add support for WebSockets

### DIFF
--- a/lib/uri/ws.rb
+++ b/lib/uri/ws.rb
@@ -3,7 +3,6 @@
 #
 # Author:: Matt Muller <mamuller@amazon.com>
 # License:: You can redistribute it and/or modify it under the same term as Ruby.
-# Revision:: $Id$
 #
 # See URI for general documentation
 #

--- a/lib/uri/ws.rb
+++ b/lib/uri/ws.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: false
+# = uri/ws.rb
+#
+# Author:: Matt Muller <mamuller@amazon.com>
+# License:: You can redistribute it and/or modify it under the same term as Ruby.
+# Revision:: $Id$
+#
+# See URI for general documentation
+#
+
+require_relative 'generic'
+
+module URI
+
+  #
+  # The syntax of WS URIs is defined in RFC6455 section 3.
+  #
+  # Note that the Ruby URI library allows WS URLs containing usernames and
+  # passwords. This is not legal as per the RFC, but used to be
+  # supported in Internet Explorer 5 and 6, before the MS04-004 security
+  # update. See <URL:http://support.microsoft.com/kb/834489>.
+  #
+  class WS < Generic
+    # A Default port of 80 for URI::WS.
+    DEFAULT_PORT = 80
+
+    # An Array of the available components for URI::WS.
+    COMPONENT = %i[
+      scheme
+      userinfo host port
+      path
+      query
+    ].freeze
+
+    #
+    # == Description
+    #
+    # Creates a new URI::WS object from components, with syntax checking.
+    #
+    # The components accepted are userinfo, host, port, path, and query.
+    #
+    # The components should be provided either as an Array, or as a Hash
+    # with keys formed by preceding the component names with a colon.
+    #
+    # If an Array is used, the components must be passed in the
+    # order <code>[userinfo, host, port, path, query]</code>.
+    #
+    # Example:
+    #
+    #     uri = URI::WS.build(host: 'www.example.com', path: '/foo/bar')
+    #
+    #     uri = URI::WS.build([nil, "www.example.com", nil, "/path", "query"])
+    #
+    # Currently, if passed userinfo components this method generates
+    # invalid WS URIs as per RFC 1738.
+    #
+    def self.build(args)
+      tmp = Util.make_components_hash(self, args)
+      super(tmp)
+    end
+
+    #
+    # == Description
+    #
+    # Returns the full path for a WS URI, as required by Net::HTTP::Get.
+    #
+    # If the URI contains a query, the full path is URI#path + '?' + URI#query.
+    # Otherwise, the path is simply URI#path.
+    #
+    # Example:
+    #
+    #     uri = URI::WS.build(path: '/foo/bar', query: 'test=true')
+    #     uri.request_uri #  => "/foo/bar?test=true"
+    #
+    def request_uri
+      return unless @path
+
+      url = @query ? "#@path?#@query" : @path.dup
+      url.start_with?(?/.freeze) ? url : ?/ + url
+    end
+  end
+
+  @@schemes['WS'] = WS
+
+end

--- a/lib/uri/wss.rb
+++ b/lib/uri/wss.rb
@@ -3,7 +3,6 @@
 #
 # Author:: Matt Muller <mamuller@amazon.com>
 # License:: You can redistribute it and/or modify it under the same term as Ruby.
-# Revision:: $Id$
 #
 # See URI for general documentation
 #

--- a/lib/uri/wss.rb
+++ b/lib/uri/wss.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: false
+# = uri/wss.rb
+#
+# Author:: Matt Muller <mamuller@amazon.com>
+# License:: You can redistribute it and/or modify it under the same term as Ruby.
+# Revision:: $Id$
+#
+# See URI for general documentation
+#
+
+require_relative 'ws'
+
+module URI
+
+  # The default port for WSS URIs is 443, and the scheme is 'wss:' rather
+  # than 'ws:'. Other than that, WSS URIs are identical to WS URIs;
+  # see URI::WS.
+  class WSS < WS
+    # A Default port of 443 for URI::WSS
+    DEFAULT_PORT = 443
+  end
+  @@schemes['WSS'] = WSS
+end

--- a/test/uri/test_ws.rb
+++ b/test/uri/test_ws.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: false
+require 'test/unit'
+require 'uri/ws'
+
+module URI
+
+
+class TestWS < Test::Unit::TestCase
+  def setup
+  end
+
+  def teardown
+  end
+
+  def uri_to_ary(uri)
+    uri.class.component.collect {|c| uri.send(c)}
+  end
+
+  def test_build
+    u = URI::WS.build(host: 'www.example.com', path: '/foo/bar')
+    assert_kind_of(URI::WS, u)
+  end
+
+  def test_parse
+    u = URI.parse('ws://a')
+    assert_kind_of(URI::WS, u)
+    assert_equal(['ws',
+		   nil, 'a', URI::HTTP.default_port,
+		   '', nil], uri_to_ary(u))
+  end
+
+  def test_normalize
+    host = 'aBcD'
+    u1 = URI.parse('ws://' + host          + '/eFg?HiJ')
+    u2 = URI.parse('ws://' + host.downcase + '/eFg?HiJ')
+    assert(u1.normalize.host == 'abcd')
+    assert(u1.normalize.path == u1.path)
+    assert(u1.normalize == u2.normalize)
+    assert(!u1.normalize.host.equal?(u1.host))
+    assert( u2.normalize.host.equal?(u2.host))
+
+    assert_equal('ws://abc/', URI.parse('ws://abc').normalize.to_s)
+  end
+
+  def test_equal
+    assert(URI.parse('ws://abc') == URI.parse('ws://ABC'))
+    assert(URI.parse('ws://abc/def') == URI.parse('ws://ABC/def'))
+    assert(URI.parse('ws://abc/def') != URI.parse('ws://ABC/DEF'))
+  end
+
+  def test_request_uri
+    assert_equal('/',         URI.parse('ws://a.b.c/').request_uri)
+    assert_equal('/?abc=def', URI.parse('ws://a.b.c/?abc=def').request_uri)
+    assert_equal('/',         URI.parse('ws://a.b.c').request_uri)
+    assert_equal('/?abc=def', URI.parse('ws://a.b.c?abc=def').request_uri)
+    assert_equal(nil,         URI.parse('ws:foo').request_uri)
+  end
+
+  def test_select
+    assert_equal(['ws', 'a.b.c', 80], URI.parse('ws://a.b.c/').select(:scheme, :host, :port))
+    u = URI.parse('ws://a.b.c/')
+    assert_equal(uri_to_ary(u), u.select(*u.component))
+    assert_raise(ArgumentError) do
+      u.select(:scheme, :host, :not_exist, :port)
+    end
+  end
+end
+
+
+end


### PR DESCRIPTION
This change adds WebSocket modules (WS and WSS) to parse WebSocket URIs.

My implementation was inspired by `HTTP` and `HTTPS` modules/tests. If I am missing anything, please let me know.

Resources I used:
https://en.wikipedia.org/wiki/WebSocket
https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Syntax

Also looked at how Python does it:
https://websockets.readthedocs.io/en/stable/_modules/websockets/uri.html

Related AWS SDK For Ruby issue:
https://github.com/aws/aws-sdk-ruby/pull/2232

RFC
https://tools.ietf.org/html/rfc6455#section-3
https://tools.ietf.org/html/rfc1738 (section 3.3 for "invalid URI with user info")