### PR TITLE
Remove RCS keywords

### DIFF
--- a/lib/uri.rb
+++ b/lib/uri.rb
@@ -86,7 +86,6 @@
 # License::
 #  Copyright (c) 2001 akira yamada <akira@ruby-lang.org>
 #  You can redistribute it and/or modify it under the same term as Ruby.
-# Revision:: $Id$
 #
 
 module URI

--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -3,7 +3,6 @@
 # = uri/common.rb
 #
 # Author:: Akira Yamada <akira@ruby-lang.org>
-# Revision:: $Id$
 # License::
 #   You can redistribute it and/or modify it under the same term as Ruby.
 #

--- a/lib/uri/ftp.rb
+++ b/lib/uri/ftp.rb
@@ -3,7 +3,6 @@
 #
 # Author:: Akira Yamada <akira@ruby-lang.org>
 # License:: You can redistribute it and/or modify it under the same term as Ruby.
-# Revision:: $Id$
 #
 # See URI for general documentation
 #

--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -4,7 +4,6 @@
 #
 # Author:: Akira Yamada <akira@ruby-lang.org>
 # License:: You can redistribute it and/or modify it under the same term as Ruby.
-# Revision:: $Id$
 #
 # See URI for general documentation
 #

--- a/lib/uri/http.rb
+++ b/lib/uri/http.rb
@@ -3,7 +3,6 @@
 #
 # Author:: Akira Yamada <akira@ruby-lang.org>
 # License:: You can redistribute it and/or modify it under the same term as Ruby.
-# Revision:: $Id$
 #
 # See URI for general documentation
 #

--- a/lib/uri/https.rb
+++ b/lib/uri/https.rb
@@ -3,7 +3,6 @@
 #
 # Author:: Akira Yamada <akira@ruby-lang.org>
 # License:: You can redistribute it and/or modify it under the same term as Ruby.
-# Revision:: $Id$
 #
 # See URI for general documentation
 #

--- a/lib/uri/ldap.rb
+++ b/lib/uri/ldap.rb
@@ -7,7 +7,6 @@
 # License::
 #   URI::LDAP is copyrighted free software by Takaaki Tateishi and Akira Yamada.
 #   You can redistribute it and/or modify it under the same term as Ruby.
-# Revision:: $Id$
 #
 # See URI for general documentation
 #

--- a/lib/uri/mailto.rb
+++ b/lib/uri/mailto.rb
@@ -3,7 +3,6 @@
 #
 # Author:: Akira Yamada <akira@ruby-lang.org>
 # License:: You can redistribute it and/or modify it under the same term as Ruby.
-# Revision:: $Id$
 #
 # See URI for general documentation
 #

--- a/lib/uri/rfc2396_parser.rb
+++ b/lib/uri/rfc2396_parser.rb
@@ -3,7 +3,6 @@
 # = uri/common.rb
 #
 # Author:: Akira Yamada <akira@ruby-lang.org>
-# Revision:: $Id$
 # License::
 #   You can redistribute it and/or modify it under the same term as Ruby.
 #


### PR DESCRIPTION
This is following @hsbt's lead in https://github.com/ruby/racc/pull/130/commits/86578511124da4dcf15b4964e8a2be7ac275d00a. Not sure if it makes sense here too, but I think these are not of any use nowadays.