### PR TITLE
Optimize URI#hostname and URI#hostname=

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -643,7 +643,7 @@ module URI
     #
     def hostname
       v = self.host
-      /\A\[(.*)\]\z/ =~ v ? $1 : v
+      v&.start_with?('[') && v.end_with?(']') ? v[1..-2] : v
     end
 
     # Sets the host part of the URI as the argument with brackets for IPv6 addresses.
@@ -659,7 +659,7 @@ module URI
     # it is wrapped with brackets.
     #
     def hostname=(v)
-      v = "[#{v}]" if /\A\[.*\]\z/ !~ v && /:/ =~ v
+      v = "[#{v}]" if !(v&.start_with?('[') && v&.end_with?(']')) && v&.index(':')
       self.host = v
     end
 

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -799,8 +799,12 @@ class URI::TestGeneric < Test::Unit::TestCase
 
     u = URI("http://foo/bar")
     assert_equal("http://foo/bar", u.to_s)
+    u.hostname = "[::1]"
+    assert_equal("http://[::1]/bar", u.to_s)
     u.hostname = "::1"
     assert_equal("http://[::1]/bar", u.to_s)
+    u.hostname = ""
+    assert_equal("http:///bar", u.to_s)
   end
 
   def test_build


### PR DESCRIPTION
Hello,

URI#hostname extends URI#host with IPv6 support. In URI, IPv6 address must have square brackets (e.g. http://[2001:db8::1]), URI#hostname strips these characters out while URI#hostname= adds them if missing. There are three regular expressions to perform these tasks which can dramatically slow down performance. I am attaching a two-line patch and here is a benchmark: https://gist.github.com/lzap/24cbecb47daf29111350e41a24250922

In short, URI#hostname is 86-89% and hostname= is 55-154% faster according to my measurements.

For the record, I created a Ruby MRI RM ticket https://bugs.ruby-lang.org/issues/17219 as I had no idea URI is a separate gem hosted on github.