### PR TITLE
Make URI friendly to Ractor

### DIFF
--- a/lib/uri.rb
+++ b/lib/uri.rb
@@ -30,7 +30,7 @@
 #     class RSYNC < Generic
 #       DEFAULT_PORT = 873
 #     end
-#     @@schemes['RSYNC'] = RSYNC
+#     register_scheme('RSYNC', RSYNC)
 #   end
 #   #=> URI::RSYNC
 #

--- a/lib/uri/file.rb
+++ b/lib/uri/file.rb
@@ -90,5 +90,5 @@ module URI
     end
   end
 
-  @@schemes['FILE'] = File
+  register_scheme('FILE', File)
 end

--- a/lib/uri/ftp.rb
+++ b/lib/uri/ftp.rb
@@ -262,5 +262,5 @@ module URI
       return str
     end
   end
-  @@schemes['FTP'] = FTP
+  register_scheme('FTP', FTP)
 end

--- a/lib/uri/http.rb
+++ b/lib/uri/http.rb
@@ -82,6 +82,6 @@ module URI
     end
   end
 
-  @@schemes['HTTP'] = HTTP
+  register_scheme('HTTP', HTTP)
 
 end

--- a/lib/uri/https.rb
+++ b/lib/uri/https.rb
@@ -18,5 +18,5 @@ module URI
     # A Default port of 443 for URI::HTTPS
     DEFAULT_PORT = 443
   end
-  @@schemes['HTTPS'] = HTTPS
+  register_scheme('HTTPS', HTTPS)
 end

--- a/lib/uri/ldap.rb
+++ b/lib/uri/ldap.rb
@@ -257,5 +257,5 @@ module URI
     end
   end
 
-  @@schemes['LDAP'] = LDAP
+  register_scheme('LDAP', LDAP)
 end

--- a/lib/uri/ldaps.rb
+++ b/lib/uri/ldaps.rb
@@ -17,5 +17,5 @@ module URI
     # A Default port of 636 for URI::LDAPS
     DEFAULT_PORT = 636
   end
-  @@schemes['LDAPS'] = LDAPS
+  register_scheme('LDAPS', LDAPS)
 end

--- a/lib/uri/mailto.rb
+++ b/lib/uri/mailto.rb
@@ -289,5 +289,5 @@ module URI
     alias to_rfc822text to_mailtext
   end
 
-  @@schemes['MAILTO'] = MailTo
+  register_scheme('MAILTO', MailTo)
 end

--- a/lib/uri/ws.rb
+++ b/lib/uri/ws.rb
@@ -79,6 +79,6 @@ module URI
     end
   end
 
-  @@schemes['WS'] = WS
+  register_scheme('WS', WS)
 
 end

--- a/lib/uri/wss.rb
+++ b/lib/uri/wss.rb
@@ -18,5 +18,5 @@ module URI
     # A Default port of 443 for URI::WSS
     DEFAULT_PORT = 443
   end
-  @@schemes['WSS'] = WSS
+  register_scheme('WSS', WSS)
 end

--- a/test/uri/test_common.rb
+++ b/test/uri/test_common.rb
@@ -33,6 +33,25 @@ class TestCommon < Test::Unit::TestCase
     end
   end
 
+  def test_ractor
+    return unless defined?(Ractor)
+    r = Ractor.new { URI.parse("https://ruby-lang.org/").inspect }
+    assert_equal(URI.parse("https://ruby-lang.org/").inspect, r.take)
+  end
+
+  def test_register_scheme
+    assert_equal(["FILE", "FTP", "HTTP", "HTTPS", "LDAP", "LDAPS", "MAILTO", "WS"].sort, URI.scheme_list.keys.sort)
+
+    original = URI.scheme_list.dup
+    begin
+      URI.register_scheme('FOOBAR', Module.new)
+      assert_equal(["FILE", "FTP", "HTTP", "HTTPS", "LDAP", "LDAPS", "MAILTO", "WS", "FOOBAR"].sort, URI.scheme_list.keys.sort)
+    ensure
+      URI.send(:remove_const, :SCHEMES)
+      URI.send(:const_set, :SCHEMES, original.freeze)
+    end
+  end
+
   def test_regexp
     EnvUtil.suppress_warning do
       assert_instance_of Regexp, URI.regexp


### PR DESCRIPTION
This PR is an updated version of https://github.com/ruby/ruby/pull/4007.

Right now, something as basic as parsing an URI cannot be done from a Ractor (I raised that earlier in https://bugs.ruby-lang.org/issues/17180):

```ruby
r = Ractor.new do
  res = URI.parse("https://ruby-lang.org/")
  puts res.inspect
end

Ractor.select(r)
```

fails with:

```
#<Thread:0x00007fbdac057028 run> terminated with exception (report_on_exception is true):
/opt/rubies/3.0.0/lib/ruby/3.0.0/uri/common.rb:68:in `scheme_list': can not access class variables from non-main Ractors (Ractor::IsolationError)
	from notractor.rb:31:in `block in <main>'
<internal:ractor>:345:in `select': thrown by remote Ractor. (Ractor::RemoteError)
	from notractor.rb:37:in `<main>'
/opt/rubies/3.0.0/lib/ruby/3.0.0/uri/common.rb:68:in `scheme_list': can not access class variables from non-main Ractors (Ractor::IsolationError)
	from notractor.rb:31:in `block in <main>'
```

IMO, something as tiny and safe as URI::parse should be allowed to be called from a Ractor.

This PR changes the `URI` class to no longer use class instance variables, and makes it a frozen Hash that is safe to be used by multiple Ractors.

I'm open to other ideas how we can make it work.

@ko1 @marcandre @akr 

Related issue on ruby-lang: https://bugs.ruby-lang.org/issues/17569