### PR TITLE
Fix markup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # URI
 
-URI is a module providing classes to handle Uniform Resource Identifiers
-(RFC2396[http://tools.ietf.org/html/rfc2396]).
+URI is a module providing classes to handle Uniform Resource Identifiers [RFC2396](http://tools.ietf.org/html/rfc2396).
 
 ## Features
 


### PR DESCRIPTION
It seems markdown syntax is wrong.

# Before
![image](https://user-images.githubusercontent.com/290782/104034426-33fd6480-5214-11eb-9529-aad23f9040db.png)

# After
![image](https://user-images.githubusercontent.com/290782/104034457-3cee3600-5214-11eb-9368-3aaed5eca504.png)
