### PR TITLE
Only use UnboundMethod#bind_call if available

### DIFF
--- a/lib/uri/rfc2396_parser.rb
+++ b/lib/uri/rfc2396_parser.rb
@@ -322,8 +322,14 @@ module URI
     end
 
     @@to_s = Kernel.instance_method(:to_s)
-    def inspect
-      @@to_s.bind_call(self)
+    if @@to_s.respond_to?(:bind_call)
+      def inspect
+        @@to_s.bind_call(self)
+      end
+    else
+      def inspect
+        @@to_s.bind(self).call
+      end
     end
 
     private

--- a/lib/uri/rfc3986_parser.rb
+++ b/lib/uri/rfc3986_parser.rb
@@ -79,8 +79,14 @@ module URI
     end
 
     @@to_s = Kernel.instance_method(:to_s)
-    def inspect
-      @@to_s.bind_call(self)
+    if @@to_s.respond_to?(:bind_call)
+      def inspect
+        @@to_s.bind_call(self)
+      end
+    else
+      def inspect
+        @@to_s.bind(self).call
+      end
     end
 
     private

--- a/test/uri/test_parser.rb
+++ b/test/uri/test_parser.rb
@@ -7,6 +7,11 @@ class URI::TestParser < Test::Unit::TestCase
     uri.class.component.collect {|c| uri.send(c)}
   end
 
+  def test_inspect
+    assert_match(/URI::RFC2396_Parser/, URI::Parser.new.inspect)
+    assert_match(/URI::RFC3986_Parser/, URI::RFC3986_Parser.new.inspect)
+  end
+
   def test_compare
     url = 'http://a/b/c/d;p?q'
     u0 = URI.parse(url)

--- a/uri.gemspec
+++ b/uri.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ruby/uri"
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
 
+  spec.required_ruby_version = '>= 2.4'
+
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
 


### PR DESCRIPTION
Add a test for inspect for Parser instances, since those are the only cases where bind_call is used.

This allows tests to pass on Ruby 2.4-2.6.  Set required_ruby_version to 2.4.