### PR TITLE
Fix parsing of scheme that are invalid Ruby constant names

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -91,8 +91,8 @@ module URI
     const_name = scheme.to_s.upcase
 
     uri_class = INITIAL_SCHEMES[const_name]
-    if !uri_class && !const_name.empty? && Schemes.const_defined?(const_name, false)
-      uri_class = Schemes.const_get(const_name, false)
+    uri_class ||= if /\A[A-Z]\w*\z/.match?(const_name) && Schemes.const_defined?(const_name, false)
+      Schemes.const_get(const_name, false)
     end
     uri_class ||= default
 

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -159,6 +159,13 @@ class URI::TestGeneric < Test::Unit::TestCase
     assert_equal(nil, url.userinfo)
   end
 
+  def test_parse_scheme_with_symbols
+    # Valid schemes from https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
+    assert_equal 'ms-search', URI.parse('ms-search://localhost').scheme
+    assert_equal 'microsoft.windows.camera', URI.parse('microsoft.windows.camera://localhost').scheme
+    assert_equal 'coaps+ws', URI.parse('coaps+ws:localhost').scheme
+  end
+
   def test_merge
     u1 = URI.parse('http://foo')
     u2 = URI.parse('http://foo/')


### PR DESCRIPTION
This fixes a regression from https://github.com/ruby/uri/pull/26

```
Error:
ActiveRecord::ConnectionAdapters::MergeAndResolveDefaultUrlConfigTest#test_url_with_hyphenated_scheme:
NameError: wrong constant name IBM-DB
 
    if !uri_class && !const_name.empty? && Schemes.const_defined?(const_name, false)
                                                  ^^^^^^^^^^^^^^^
    /usr/local/lib/ruby/3.1.0/uri/common.rb:94:in `const_defined?'
    /usr/local/lib/ruby/3.1.0/uri/common.rb:94:in `for'
    /usr/local/lib/ruby/3.1.0/uri/rfc2396_parser.rb:210:in `parse'
    /rails/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb:25:in `initialize'
    /rails/activerecord/lib/active_record/database_configurations/url_config.rb:48:in `new'
    /rails/activerecord/lib/active_record/database_configurations/url_config.rb:48:in `build_url_hash'
    /rails/activerecord/lib/active_record/database_configurations/url_config.rb:38:in `initialize'
    /rails/activerecord/lib/active_record/database_configurations.rb:262:in `new'
    /rails/activerecord/lib/active_record/database_configurations.rb:262:in `environment_url_config'
    /rails/activerecord/lib/active_record/database_configurations.rb:253:in `block in merge_db_environment_variables'
    /rails/activerecord/lib/active_record/database_configurations.rb:250:in `map'
    /rails/activerecord/lib/active_record/database_configurations.rb:250:in `merge_db_environment_variables'
    /rails/activerecord/lib/active_record/database_configurations.rb:180:in `build_configs'
    /rails/activerecord/lib/active_record/database_configurations.rb:19:in `initialize'
    /rails/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb:26:in `new'
    /rails/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb:26:in `resolve_db_config'
    /rails/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb:157:in `test_url_with_hyphenated_scheme'
 
rails test rails/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb:154
```

https://buildkite.com/rails/rails/builds/79689#6a1b7cfc-fa17-4752-bc27-62158a228e79/1018-1029

Some symbols such as `-`, `+` or `.` are valid inside URI schemes.
See: https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml

@eregon @hsbt 