### PR TITLE
Improve URI.register_scheme tests and automatically upcase the given scheme

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -68,8 +68,13 @@ module URI
   end
   private_constant :Schemes
 
+  #
+  # Register the given +klass+ to be instantiated when parsing URLs with the given +scheme+.
+  # Note that currently only schemes which after .upcase are valid constant names
+  # can be registered (no -/+/. allowed).
+  #
   def self.register_scheme(scheme, klass)
-    Schemes.const_set(scheme, klass)
+    Schemes.const_set(scheme.to_s.upcase, klass)
   end
 
   # Returns a Hash of the defined schemes.


### PR DESCRIPTION
* Also add docs and mention current limitations.
* For reference, https://stackoverflow.com/a/3641782/388803 mentions the
  valid characters in schemes.

Follow-up of https://github.com/ruby/uri/pull/27#discussion_r677858406
cc @byroot / @casperisfine and @hsbt

Maybe +/-/. could be supported by replacing them with some other characters valid as constant names, but not sure how to avoid conflicts (replacing all 3 with just `_` seems bad), and whether someone would actually want a custom URI::Generic subclass for a scheme. Also any extra replacement to `.upcase` will make `URI.for` slower for non-initial schemes.