### PR TITLE
URI#HTTP#origin and URI#HTTP#authority

### DIFF
--- a/lib/uri/http.rb
+++ b/lib/uri/http.rb
@@ -95,8 +95,11 @@ module URI
     #     URI::HTTP.build(host: 'www.example.com', port: 80, path: '/foo/bar').authority #=> "www.example.com"
     #
     def authority
-      port_string = port == default_port ? nil : ":#{port}"
-      "#{host}#{port_string}"
+      if port == default_port
+        host
+      else
+        "#{host}:#{port}"
+      end
     end
 
     #

--- a/lib/uri/http.rb
+++ b/lib/uri/http.rb
@@ -80,6 +80,42 @@ module URI
       url = @query ? "#@path?#@query" : @path.dup
       url.start_with?(?/.freeze) ? url : ?/ + url
     end
+
+    #
+    # == Description
+    #
+    # Returns the authority for an HTTP uri, as defined in
+    # https://datatracker.ietf.org/doc/html/rfc3986/#section-3.2.
+    #
+    #
+    # Example:
+    #
+    #     URI::HTTP.build(host: 'www.example.com', path: '/foo/bar').authority #=> "www.example.com"
+    #     URI::HTTP.build(host: 'www.example.com', port: 8000, path: '/foo/bar').authority #=> "www.example.com:8000"
+    #     URI::HTTP.build(host: 'www.example.com', port: 80, path: '/foo/bar').authority #=> "www.example.com"
+    #
+    def authority
+      port_string = port == default_port ? nil : ":#{port}"
+      "#{host}#{port_string}"
+    end
+
+    #
+    # == Description
+    #
+    # Returns the origin for an HTTP uri, as defined in
+    # https://datatracker.ietf.org/doc/html/rfc6454.
+    #
+    #
+    # Example:
+    #
+    #     URI::HTTP.build(host: 'www.example.com', path: '/foo/bar').origin #=> "http://www.example.com"
+    #     URI::HTTP.build(host: 'www.example.com', port: 8000, path: '/foo/bar').origin #=> "http://www.example.com:8000"
+    #     URI::HTTP.build(host: 'www.example.com', port: 80, path: '/foo/bar').origin #=> "http://www.example.com"
+    #     URI::HTTPS.build(host: 'www.example.com', path: '/foo/bar').origin #=> "https://www.example.com"
+    #
+    def origin
+      "#{scheme}://#{authority}"
+    end
   end
 
   register_scheme 'HTTP', HTTP

--- a/test/uri/test_http.rb
+++ b/test/uri/test_http.rb
@@ -64,6 +64,20 @@ class TestHTTP < Test::Unit::TestCase
       u.select(:scheme, :host, :not_exist, :port)
     end
   end
+
+  def test_authority
+    assert_equal('a.b.c',         URI.parse('http://a.b.c/').authority)
+    assert_equal('a.b.c:8081',         URI.parse('http://a.b.c:8081/').authority)
+    assert_equal('a.b.c',         URI.parse('http://a.b.c:80/').authority)
+  end
+
+
+  def test_origin
+    assert_equal('http://a.b.c',         URI.parse('http://a.b.c/').origin)
+    assert_equal('http://a.b.c:8081',         URI.parse('http://a.b.c:8081/').origin)
+    assert_equal('http://a.b.c',         URI.parse('http://a.b.c:80/').origin)
+    assert_equal('https://a.b.c',         URI.parse('https://a.b.c/').origin)
+  end
 end
 
 

--- a/test/uri/test_http.rb
+++ b/test/uri/test_http.rb
@@ -24,14 +24,16 @@ class TestHTTP < Test::Unit::TestCase
   def test_parse
     u = URI.parse('http://a')
     assert_kind_of(URI::HTTP, u)
-    assert_equal(['http',
-		   nil, 'a', URI::HTTP.default_port,
-		   '', nil, nil], uri_to_ary(u))
+    assert_equal([
+      'http',
+      nil, 'a', URI::HTTP.default_port,
+      '', nil, nil
+    ], uri_to_ary(u))
   end
 
   def test_normalize
     host = 'aBcD'
-    u1 = URI.parse('http://' + host          + '/eFg?HiJ')
+    u1 = URI.parse('http://' + host + '/eFg?HiJ')
     u2 = URI.parse('http://' + host.downcase + '/eFg?HiJ')
     assert(u1.normalize.host == 'abcd')
     assert(u1.normalize.path == u1.path)
@@ -49,11 +51,11 @@ class TestHTTP < Test::Unit::TestCase
   end
 
   def test_request_uri
-    assert_equal('/',         URI.parse('http://a.b.c/').request_uri)
+    assert_equal('/', URI.parse('http://a.b.c/').request_uri)
     assert_equal('/?abc=def', URI.parse('http://a.b.c/?abc=def').request_uri)
-    assert_equal('/',         URI.parse('http://a.b.c').request_uri)
+    assert_equal('/', URI.parse('http://a.b.c').request_uri)
     assert_equal('/?abc=def', URI.parse('http://a.b.c?abc=def').request_uri)
-    assert_equal(nil,         URI.parse('http:foo').request_uri)
+    assert_equal(nil, URI.parse('http:foo').request_uri)
   end
 
   def test_select
@@ -66,17 +68,17 @@ class TestHTTP < Test::Unit::TestCase
   end
 
   def test_authority
-    assert_equal('a.b.c',         URI.parse('http://a.b.c/').authority)
-    assert_equal('a.b.c:8081',         URI.parse('http://a.b.c:8081/').authority)
-    assert_equal('a.b.c',         URI.parse('http://a.b.c:80/').authority)
+    assert_equal('a.b.c', URI.parse('http://a.b.c/').authority)
+    assert_equal('a.b.c:8081', URI.parse('http://a.b.c:8081/').authority)
+    assert_equal('a.b.c', URI.parse('http://a.b.c:80/').authority)
   end
 
 
   def test_origin
-    assert_equal('http://a.b.c',         URI.parse('http://a.b.c/').origin)
-    assert_equal('http://a.b.c:8081',         URI.parse('http://a.b.c:8081/').origin)
-    assert_equal('http://a.b.c',         URI.parse('http://a.b.c:80/').origin)
-    assert_equal('https://a.b.c',         URI.parse('https://a.b.c/').origin)
+    assert_equal('http://a.b.c', URI.parse('http://a.b.c/').origin)
+    assert_equal('http://a.b.c:8081', URI.parse('http://a.b.c:8081/').origin)
+    assert_equal('http://a.b.c', URI.parse('http://a.b.c:80/').origin)
+    assert_equal('https://a.b.c', URI.parse('https://a.b.c/').origin)
   end
 end
 


### PR DESCRIPTION
Attempt at porting to mainline an abstraction that I've been using successfuly (as a refinement) over +3y. (ref: https://gitlab.com/honeyryderchuck/httpx/-/blob/master/lib/httpx/extensions.rb#L124-131).

`authority` and `origin` are concepts which I see reinvented (and reimplemented) in a lot of ruby HTTP infrastructure (`rack`, app servers like `puma`, `net-http`  itself). It's usefulness is so fundamental on so many levels (connection pools by origin, check by `Host` header, some rack spec fields) that ` uri` could abstract it away.

