### PR TITLE
Document requirement that path be escaped

### DIFF
--- a/lib/uri/file.rb
+++ b/lib/uri/file.rb
@@ -33,6 +33,9 @@ module URI
     # If an Array is used, the components must be passed in the
     # order <code>[host, path]</code>.
     #
+    # A path from e.g. the File class should be escaped before
+    # being passed.
+    #
     # Examples:
     #
     #     require 'uri'
@@ -43,6 +46,9 @@ module URI
     #     uri2 = URI::File.build({:host => 'host.example.com',
     #       :path => '/ruby/src'})
     #     uri2.to_s  # => "file://host.example.com/ruby/src"
+    #
+    #     uri3 = URI::File.build({:path => URI::escape('/path/my file.txt')})
+    #     uri3.to_s  # => "file:///path/my%20file.txt"
     #
     def self.build(args)
       tmp = Util::make_components_hash(self, args)


### PR DESCRIPTION
The module here is called `URI`, so it's probably reasonable to expect a requirement for the path to be RFC3986-compliant.

On the other hand, the class is called `File`, so it might be reasonable to expect that a path produced by e.g. Ruby's built-in `File` class would be consumable by this `build` method (it fails if the filename contains e.g. a space).