### PR TITLE
Add space after `bad URI`

### DIFF
--- a/lib/uri/rfc2396_parser.rb
+++ b/lib/uri/rfc2396_parser.rb
@@ -140,11 +140,11 @@ module URI
 
         if !scheme
           raise InvalidURIError,
-            "bad URI(absolute but no scheme): #{uri}"
+            "bad URI (absolute but no scheme): #{uri}"
         end
         if !opaque && (!path && (!host && !registry))
           raise InvalidURIError,
-            "bad URI(absolute but no path): #{uri}"
+            "bad URI (absolute but no path): #{uri}"
         end
 
       when @regexp[:REL_URI]
@@ -173,7 +173,7 @@ module URI
         # server        = [ [ userinfo "@" ] hostport ]
 
       else
-        raise InvalidURIError, "bad URI(is not URI?): #{uri}"
+        raise InvalidURIError, "bad URI (is not URI?): #{uri}"
       end
 
       path = '' if !path && !opaque # (see RFC2396 Section 5.2)

--- a/lib/uri/rfc3986_parser.rb
+++ b/lib/uri/rfc3986_parser.rb
@@ -78,7 +78,7 @@ module URI
       begin
         uri = uri.to_str
       rescue NoMethodError
-        raise InvalidURIError, "bad URI(is not URI?): #{uri.inspect}"
+        raise InvalidURIError, "bad URI (is not URI?): #{uri.inspect}"
       end
       uri.ascii_only? or
         raise InvalidURIError, "URI must be ascii only #{uri.dump}"
@@ -127,7 +127,7 @@ module URI
           m["fragment"]
         ]
       else
-        raise InvalidURIError, "bad URI(is not URI?): #{uri.inspect}"
+        raise InvalidURIError, "bad URI (is not URI?): #{uri.inspect}"
       end
     end
 


### PR DESCRIPTION
I'm running `dkhamsing/awesome_bot:1.20.0` and it generated things like:

> bad URI(is not URI?): "http://nginx.org/en/docs/http/ngx_http_map_module.html#map](http://nginx.org/en/docs/http/ngx_http_map_module.html"