### PR TITLE
Include RFC2396_REGEXP module directly

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -13,6 +13,8 @@ require_relative "rfc2396_parser"
 require_relative "rfc3986_parser"
 
 module URI
+  include RFC2396_REGEXP
+
   REGEXP = RFC2396_REGEXP
   Parser = RFC2396_Parser
   RFC3986_PARSER = RFC3986_Parser.new
@@ -61,8 +63,6 @@ module URI
     end
     module_function :make_components_hash
   end
-
-  include REGEXP
 
   module Schemes
   end

--- a/lib/uri/mailto.rb
+++ b/lib/uri/mailto.rb
@@ -15,7 +15,7 @@ module URI
   # RFC6068, the mailto URL scheme.
   #
   class MailTo < Generic
-    include REGEXP
+    include RFC2396_REGEXP
 
     # A Default port of nil for URI::MailTo.
     DEFAULT_PORT = nil


### PR DESCRIPTION
REGEXP is defined as RFC2396_REGEXP in lib/uri/common.rb. If we include
REGEXP then a broken URL is generated in rdoc for URI and URI::MailTo.