### PR TITLE
Fix host part in relative referece

### DIFF
--- a/lib/uri/rfc3986_parser.rb
+++ b/lib/uri/rfc3986_parser.rb
@@ -26,11 +26,6 @@ module URI
     ]x
 
     USERINFO = /(?:%\h\h|[!$&-.0-9:;=A-Z_a-z~])*+/
-    AUTHORITY = %r[
-      (?:(?<userinfo>#{USERINFO.source})@)?
-      (?<host>#{HOST.source.delete(" \n")})
-      (?::(?<port>\d*+))?
-    ]x
 
     SCHEME = %r[[A-Za-z][+\-.0-9A-Za-z]*+].source
     SEG = %r[(?:%\h\h|[!$&-.0-9:;=@A-Z_a-z~/])].source
@@ -42,7 +37,11 @@ module URI
     (?<URI>
       (?<scheme>#{SCHEME}):
       (?<hier-part>//
-        (?<authority>#{AUTHORITY})
+        (?<authority>
+          (?:(?<userinfo>#{USERINFO.source})@)?
+          (?<host>#{HOST.source.delete(" \n")})
+          (?::(?<port>\d*+))?
+        )
         (?<path-abempty>(?:/\g<seg>*+)?)
       | (?<path-absolute>/((?!/)\g<seg>++)?)
       | (?<path-rootless>(?!/)\g<seg>++)
@@ -56,7 +55,11 @@ module URI
     (?<seg>#{SEG}){0}
     (?<relative-ref>
       (?<relative-part>//
-        (?<authority>#{AUTHORITY})
+        (?<authority>
+          (?:(?<userinfo>#{USERINFO.source})@)?
+          (?<host>#{HOST.source.delete(" \n")}(?<!/))?
+          (?::(?<port>\d*+))?
+        )
         (?<path-abempty>(?:/\g<seg>*+)?)
       | (?<path-absolute>/\g<seg>*+)
       | (?<path-noscheme>#{SEG_NC}++(?:/\g<seg>*+)?)

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -977,6 +977,10 @@ class URI::TestGeneric < Test::Unit::TestCase
     end
   end
 
+  def test_split
+    assert_equal [nil, nil, nil, nil, nil, "", nil, nil, nil], URI.split("//")
+  end
+
   class CaseInsensitiveEnv
     def initialize(h={})
       @h = {}


### PR DESCRIPTION
In relative referece, host part can be ommitted but can not be empty.