### PR TITLE
Make URI#to_s prepend relative path with / if there is a host or port

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -1364,6 +1364,9 @@ module URI
           str << ':'
           str << @port.to_s
         end
+        if (@host || @port) && !@path.empty? && !@path.start_with?('/')
+          str << '/'
+        end
         str << @path
         if @query
           str << '?'

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -26,6 +26,17 @@ class URI::TestGeneric < Test::Unit::TestCase
     assert_equal "postgres:///foo", URI("postgres:///foo").to_s
     assert_equal "http:///foo", URI("http:///foo").to_s
     assert_equal "http:/foo", URI("http:/foo").to_s
+
+    uri = URI('rel_path')
+    assert_equal "rel_path", uri.to_s
+    uri.scheme = 'http'
+    assert_equal "http:rel_path", uri.to_s
+    uri.host = 'h'
+    assert_equal "http://h/rel_path", uri.to_s
+    uri.port = 8080
+    assert_equal "http://h:8080/rel_path", uri.to_s
+    uri.host = nil
+    assert_equal "http::8080/rel_path", uri.to_s
   end
 
   def test_parse


### PR DESCRIPTION
Otherwise, the path could be considered part of the host or port.

This is better than modifying the path to make it absolute when a host or port is set.  We could also raise for invalid paths when a host or port is set using check_path, but that results in weird errors, and won't catch issues (such as ftp allowing a relative path).

Fixes [Bug #19916]