### PR TITLE
Remove URI from error messages

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -205,7 +205,7 @@ module URI
       end
       if registry
         raise InvalidURIError,
-          "the scheme #{@scheme} does not accept registry part: #{registry} (or bad hostname?)"
+          "the scheme #{@scheme} does not accept registry part (or bad hostname?)"
       end
 
       @scheme&.freeze

--- a/lib/uri/rfc3986_parser.rb
+++ b/lib/uri/rfc3986_parser.rb
@@ -78,10 +78,10 @@ module URI
       begin
         uri = uri.to_str
       rescue NoMethodError
-        raise InvalidURIError, "bad URI(is not URI?): #{uri.inspect}"
+        raise InvalidURIError, "bad URI(is not URI?)"
       end
       uri.ascii_only? or
-        raise InvalidURIError, "URI must be ascii only #{uri.dump}"
+        raise InvalidURIError, "URI must be ascii only"
       if m = RFC3986_URI.match(uri)
         query = m["query"]
         scheme = m["scheme"]
@@ -127,7 +127,7 @@ module URI
           m["fragment"]
         ]
       else
-        raise InvalidURIError, "bad URI(is not URI?): #{uri.inspect}"
+        raise InvalidURIError, "bad URI(is not URI?)"
       end
     end
 


### PR DESCRIPTION
Since a URI may contain a password, it'd be good to keep it out of error messages (to keep it from ending up in logging or exception reporting services). For instance:

```ruby
URI.parse("https://user:password@example.com/[")
```

currently raises

```text
bad URI(is not URI?): "https://user:password@example.com/[" (URI::InvalidURIError)
```
