### PR TITLE
Use https instead of http

### DIFF
--- a/lib/uri.rb
+++ b/lib/uri.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
 # URI is a module providing classes to handle Uniform Resource Identifiers
-# (RFC2396[http://tools.ietf.org/html/rfc2396]).
+# (RFC2396[https://datatracker.ietf.org/doc/html/rfc2396]).
 #
 # == Features
 #
@@ -47,14 +47,14 @@
 # A good place to view an RFC spec is http://www.ietf.org/rfc.html.
 #
 # Here is a list of all related RFC's:
-# - RFC822[http://tools.ietf.org/html/rfc822]
-# - RFC1738[http://tools.ietf.org/html/rfc1738]
-# - RFC2255[http://tools.ietf.org/html/rfc2255]
-# - RFC2368[http://tools.ietf.org/html/rfc2368]
-# - RFC2373[http://tools.ietf.org/html/rfc2373]
-# - RFC2396[http://tools.ietf.org/html/rfc2396]
-# - RFC2732[http://tools.ietf.org/html/rfc2732]
-# - RFC3986[http://tools.ietf.org/html/rfc3986]
+# - RFC822[https://datatracker.ietf.org/doc/html/rfc822]
+# - RFC1738[https://datatracker.ietf.org/doc/html/rfc1738]
+# - RFC2255[https://datatracker.ietf.org/doc/html/rfc2255]
+# - RFC2368[https://datatracker.ietf.org/doc/html/rfc2368]
+# - RFC2373[https://datatracker.ietf.org/doc/html/rfc2373]
+# - RFC2396[https://datatracker.ietf.org/doc/html/rfc2396]
+# - RFC2732[https://datatracker.ietf.org/doc/html/rfc2732]
+# - RFC3986[https://datatracker.ietf.org/doc/html/rfc3986]
 #
 # == Class tree
 #

--- a/lib/uri/ftp.rb
+++ b/lib/uri/ftp.rb
@@ -17,7 +17,7 @@ module URI
   # This class will be redesigned because of difference of implementations;
   # the structure of its path. draft-hoffman-ftp-uri-04 is a draft but it
   # is a good summary about the de facto spec.
-  # http://tools.ietf.org/html/draft-hoffman-ftp-uri-04
+  # https://datatracker.ietf.org/doc/html/draft-hoffman-ftp-uri-04
   #
   class FTP < Generic
     # A Default port of 21 for URI::FTP.


### PR DESCRIPTION
`http://tools.ietf.org/html/` is redirected to `https://datatracker.ietf.org/doc/html/` today.