### PR TITLE
Update URI::Generic.build/build2 to use RFC3986_PARSER

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -158,7 +158,7 @@ module URI
     # +fragment+::
     #   Part of the URI after '#' character.
     # +parser+::
-    #   Parser for internal use [URI::DEFAULT_PARSER by default].
+    #   Parser for internal use [URI::RFC3986_PARSER by default].
     # +arg_check+::
     #   Check arguments [false by default].
     #
@@ -171,7 +171,7 @@ module URI
                    path, opaque,
                    query,
                    fragment,
-                   parser = DEFAULT_PARSER,
+                   parser = RFC3986_PARSER,
                    arg_check = false)
       @scheme = nil
       @user = nil
@@ -182,7 +182,7 @@ module URI
       @query = nil
       @opaque = nil
       @fragment = nil
-      @parser = parser == DEFAULT_PARSER ? nil : parser
+      @parser = parser == RFC3986_PARSER ? nil : parser
 
       if arg_check
         self.scheme = scheme
@@ -284,13 +284,13 @@ module URI
 
     # Returns the parser to be used.
     #
-    # Unless a URI::Parser is defined, DEFAULT_PARSER is used.
+    # Unless a URI::Parser is defined, RFC3986_PARSER is used.
     #
     def parser
       if !defined?(@parser) || !@parser
-        DEFAULT_PARSER
+        RFC3986_PARSER
       else
-        @parser || DEFAULT_PARSER
+        @parser || RFC3986_PARSER
       end
     end
 

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -841,6 +841,10 @@ class URI::TestGeneric < Test::Unit::TestCase
     assert_equal(":5432", u.to_s)
     assert_equal(5432, u.port)
 
+    u = URI::Generic.build(:host => "underscore_host.test")
+    assert_equal("//underscore_host.test", u.to_s)
+    assert_equal("underscore_host.test", u.host)
+
     u = URI::Generic.build(:scheme => "http", :host => "::1", :path => "/bar/baz")
     assert_equal("http://[::1]/bar/baz", u.to_s)
     assert_equal("[::1]", u.host)


### PR DESCRIPTION
[Description below cross-posted from [https://bugs.ruby-lang.org/issues/19266](https://bugs.ruby-lang.org/issues/19266)]

---
In June 2014, [uri/common was updated](https://github.com/ruby/ruby/commit/bb83f32dc3e0424d25fa4e55d8ff32b061320e41) to introduce a RFC3986-compliant parser (`URI::RFC3986_PARSER`) as an alternative to the previous RFC2396 parser, and common methods like `URI()` were updated to use that new parser by default. The only methods in `common` not updated were [`URI.extract` and `URI.regexp`](https://github.com/ruby/ruby/blob/28a17436503c3c4cb7a35b423a894b697cd80da9/lib/uri/common.rb#L233-L297) which are marked as obsolete. (The old parser was kept in the `DEFAULT_PARSER` constant despite it not being the default for those methods, presumably for backward compatibility.)

However, similar [methods called on `URI::Generic`](https://github.com/ruby/ruby/blob/28a17436503c3c4cb7a35b423a894b697cd80da9/lib/uri/generic.rb#L169-L175) were never updated to use this new parser. This means that methods like `URI::Generic.build` fail when given input that succeeds normally, and this also affects subclasses like `URI::HTTP`:

```
$ pry -r uri -r uri/common -r uri/generic

[1] pry(main)> URI::Generic.build(host: "underscore_host.example")
URI::InvalidComponentError: bad component(expected host component): underscore_host.example
from /Users/gareth/.asdf/installs/ruby/3.1.3/lib/ruby/3.1.0/uri/generic.rb:591:in `check_host'

[2] pry(main)> URI::HTTP.build(host: "underscore_host.example")
URI::InvalidComponentError: bad component(expected host component): underscore_host.example
from /Users/gareth/.asdf/installs/ruby/3.1.3/lib/ruby/3.1.0/uri/generic.rb:591:in `check_host'

[3] pry(main)> URI("http://underscore_host.example")
=> #<URI::HTTP http://underscore_host.example>
```

`URI::Generic.new` allows a configurable `parser` positional argument to override the class' default parser, but other factory methods like `.build` don't allow this override.

Arguably this doesn't cause problems because at least in the case above, the URI can be built with the polymorphic constructor, but having the option to build URIs from explicit named parts is useful, and leaving the outdated functionality in the `Generic` class is ambiguous. It's possible that the whole Generic class and its subclasses aren't intended to be used directly how I'm intending here, but there's nothing I could see that suggested this is the case.

I'm not aware of the entire list of differences between RFC2396 and RFC3986. The relevant difference here is that in RFC2396 an individual segment of a host ([`domainlabel`s](https://www.rfc-editor.org/rfc/rfc2396#section-3.2.2)) could only be `alphanum | alphanum *( alphanum | "-" ) alphanum`, whereas RFC3986 allows [hostnames](https://www.rfc-editor.org/rfc/rfc3986#page-13) to include any of `ALPHA / DIGIT / "-" / "." / "_" / "~"`. It's possible that other differences might cause issues for developers, but since this has gone over 9 years without anyone else caring about this, this is definitely not especially urgent.