### PR TITLE
Restrict const checks to current namespace to avoid conflict with globals

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -23,11 +23,11 @@ module URI
   Ractor.make_shareable(DEFAULT_PARSER) if defined?(Ractor)
 
   def self.parser=(parser = RFC3986_PARSER)
-    remove_const(:Parser) if defined?(Parser)
+    remove_const(:Parser) if defined?(::URI::Parser)
     const_set("Parser", parser.class)
 
-    remove_const(:REGEXP) if defined?(REGEXP)
-    remove_const(:PATTERN) if defined?(PATTERN)
+    remove_const(:REGEXP) if defined?(::URI::REGEXP)
+    remove_const(:PATTERN) if defined?(::URI::PATTERN)
     if Parser == RFC2396_Parser
       const_set("REGEXP", URI::RFC2396_REGEXP)
       const_set("PATTERN", URI::RFC2396_REGEXP::PATTERN)


### PR DESCRIPTION
Getting this error on latest master when a top-level Parser constant is defined before URI is loaded:

```
$ ruby -Ilib -e 'module Parser; end; require "uri/common"'
/Users/rwstauner/src/github.com/ruby/uri/lib/uri/common.rb:26:in `remove_const': constant URI::Parser not defined (NameError)

    remove_const(:Parser) if defined?(Parser)
    ^^^^^^^^^^^^
        from /Users/rwstauner/src/github.com/ruby/uri/lib/uri/common.rb:26:in `parser='
        from /Users/rwstauner/src/github.com/ruby/uri/lib/uri/common.rb:46:in `<module:URI>'
        from /Users/rwstauner/src/github.com/ruby/uri/lib/uri/common.rb:15:in `<top (required)>'
        from <internal:/Users/rwstauner/.rubies/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
        from <internal:/Users/rwstauner/.rubies/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
        from -e:1:in `<main>'
```