### PR TITLE
Use Ruby 3.3 for gh_pages build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.3'
           bundler-cache: true
       - name: Setup Pages
         id: pages


### PR DESCRIPTION
Hopefully this will fix the following error:

You have already activated uri 0.12.1, but your Gemfile requires uri 0.13.0. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem.

https://github.com/ruby/uri/actions/runs/10029934700/job/27718711665#step:5:38