### PR TITLE
Use DEFAULT_PARSER at split, parse, join

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -181,7 +181,7 @@ module URI
   #    ["fragment", "top"]]
   #
   def self.split(uri)
-    RFC3986_PARSER.split(uri)
+    DEFAULT_PARSER.split(uri)
   end
 
   # Returns a new \URI object constructed from the given string +uri+:
@@ -195,7 +195,7 @@ module URI
   # if it may contain invalid URI characters.
   #
   def self.parse(uri)
-    RFC3986_PARSER.parse(uri)
+    DEFAULT_PARSER.parse(uri)
   end
 
   # Merges the given URI strings +str+
@@ -222,7 +222,7 @@ module URI
   #   # => #<URI::HTTP http://example.com/foo/bar>
   #
   def self.join(*str)
-    RFC3986_PARSER.join(*str)
+    DEFAULT_PARSER.join(*str)
   end
 
   #


### PR DESCRIPTION
`URI.split`, `URI.parse` and `URI.join` always uses `RFC3986_PARSER` from https://github.com/ruby/uri/commit/d8c414e99dda6cbb0bf91b9ad5f6a95321e00435

The current HEAD uses `RFC3986_PARSER` as `DEFAULT_PARSER`. We should allow to switch Parser behavior with user configuration.