### PR TITLE
Fallback missing constants with RFC3986_PARSER

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -50,7 +50,7 @@ module URI
       warn "URI::#{const} is obsolete. Use RFC2396_PARSER.regexp[#{const.inspect}] explicitly.", uplevel: 1 if $VERBOSE
       RFC2396_PARSER.regexp[const]
     else
-      raise NameError, "uninitialized constant URI::#{const}"
+      super
     end
   end
 

--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -45,6 +45,13 @@ module URI
   end
   self.parser = RFC3986_PARSER
 
+  def self.const_missing(const)
+    if RFC2396_PARSER.regexp[const]
+      warn "URI::#{const} is obsolete. Use RFC2396_PARSER.regexp[#{const.inspect}] explicitly.", uplevel: 1 if $VERBOSE
+      RFC2396_PARSER.regexp[const]
+    end
+  end
+
   module Util # :nodoc:
     def make_components_hash(klass, array_hash)
       tmp = {}

--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -46,9 +46,9 @@ module URI
   self.parser = RFC3986_PARSER
 
   def self.const_missing(const)
-    if RFC2396_PARSER.regexp[const]
+    if value = RFC2396_PARSER.regexp[const]
       warn "URI::#{const} is obsolete. Use RFC2396_PARSER.regexp[#{const.inspect}] explicitly.", uplevel: 1 if $VERBOSE
-      RFC2396_PARSER.regexp[const]
+      value
     else
       super
     end

--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -49,6 +49,8 @@ module URI
     if RFC2396_PARSER.regexp[const]
       warn "URI::#{const} is obsolete. Use RFC2396_PARSER.regexp[#{const.inspect}] explicitly.", uplevel: 1 if $VERBOSE
       RFC2396_PARSER.regexp[const]
+    else
+      raise NameError, "uninitialized constant URI::#{const}"
     end
   end
 

--- a/test/uri/test_common.rb
+++ b/test/uri/test_common.rb
@@ -15,6 +15,7 @@ class URI::TestCommon < Test::Unit::TestCase
     $VERBOSE = nil
     assert URI::ABS_URI
     assert_raise(NameError) { URI::FOO }
+  ensure
     $VERBOSE = orig_verbose
   end
 

--- a/test/uri/test_common.rb
+++ b/test/uri/test_common.rb
@@ -10,6 +10,13 @@ class URI::TestCommon < Test::Unit::TestCase
   def teardown
   end
 
+  def test_fallback_constants
+    orig_verbose = $VERBOSE
+    $VERBOSE = nil
+    assert URI::ABS_URI
+    $VERBOSE = orig_verbose
+  end
+
   def test_parser_switch
     assert_equal(URI::Parser, URI::RFC3986_Parser)
     refute defined?(URI::REGEXP)

--- a/test/uri/test_common.rb
+++ b/test/uri/test_common.rb
@@ -14,6 +14,7 @@ class URI::TestCommon < Test::Unit::TestCase
     orig_verbose = $VERBOSE
     $VERBOSE = nil
     assert URI::ABS_URI
+    assert_raise(NameError) { URI::FOO }
     $VERBOSE = orig_verbose
   end
 


### PR DESCRIPTION
Fixed https://github.com/ruby/uri/issues/112

Related issue is here:
* https://github.com/octokit/octokit.rb/pull/1708
* https://github.com/omniauth/omniauth/pull/1136

/cc @byroot 