### PR TITLE
Do not allow empty host names, as they are not allowed by RFC 3986

### DIFF
--- a/lib/uri/http.rb
+++ b/lib/uri/http.rb
@@ -61,6 +61,18 @@ module URI
       super(tmp)
     end
 
+    # Do not allow empty host names, as they are not allowed by RFC 3986.
+    def check_host(v)
+      ret = super
+
+      if ret && v.empty?
+        raise InvalidComponentError,
+          "bad component(expected host component): #{v}"
+      end
+
+      ret
+    end
+
     #
     # == Description
     #

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -828,8 +828,10 @@ class URI::TestGeneric < Test::Unit::TestCase
     assert_equal("http://[::1]/bar", u.to_s)
     u.hostname = "::1"
     assert_equal("http://[::1]/bar", u.to_s)
-    u.hostname = ""
-    assert_equal("http:///bar", u.to_s)
+
+    u = URI("file://foo/bar")
+    u.hostname = ''
+    assert_equal("file:///bar", u.to_s)
   end
 
   def test_build

--- a/test/uri/test_http.rb
+++ b/test/uri/test_http.rb
@@ -19,6 +19,10 @@ class URI::TestHTTP < Test::Unit::TestCase
     assert_kind_of(URI::HTTP, u)
   end
 
+  def test_build_empty_host
+    assert_raise(URI::InvalidComponentError) { URI::HTTP.build(host: '') }
+  end
+
   def test_parse
     u = URI.parse('http://a')
     assert_kind_of(URI::HTTP, u)


### PR DESCRIPTION
Pointed out by John Hawthorn.

Fixes [Bug #20686]