### PR TITLE
Tilde should not be escaped as per RFC3986

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -324,14 +324,14 @@ module URI
   #
   # - Preserves:
   #
-  #   - Characters <tt>'*'</tt>, <tt>'.'</tt>, <tt>'-'</tt>, and <tt>'_'</tt>.
+  #   - Characters <tt>'*'</tt>, <tt>'.'</tt>, <tt>'-'</tt>, <tt>'_'</tt>, and <tt>'~'</tt>.
   #   - Character in ranges <tt>'a'..'z'</tt>, <tt>'A'..'Z'</tt>,
   #     and <tt>'0'..'9'</tt>.
   #
   #   Example:
   #
-  #     URI.encode_www_form_component('*.-_azAZ09')
-  #     # => "*.-_azAZ09"
+  #     URI.encode_www_form_component('*.-_~azAZ09')
+  #     # => "*.-_~azAZ09"
   #
   # - Converts:
   #
@@ -355,7 +355,7 @@ module URI
   #
   # Related: URI.encode_uri_component (encodes <tt>' '</tt> as <tt>'%20'</tt>).
   def self.encode_www_form_component(str, enc=nil)
-    _encode_uri_component(/[^*\-.0-9A-Z_a-z]/, TBLENCWWWCOMP_, str, enc)
+    _encode_uri_component(/[^*\-.~0-9A-Z_a-z]/, TBLENCWWWCOMP_, str, enc)
   end
 
   # Returns a string decoded from the given \URL-encoded string +str+.
@@ -394,7 +394,7 @@ module URI
   # Like URI.encode_www_form_component, except that <tt>' '</tt> (space)
   # is encoded as <tt>'%20'</tt> (instead of <tt>'+'</tt>).
   def self.encode_uri_component(str, enc=nil)
-    _encode_uri_component(/[^*\-.0-9A-Z_a-z]/, TBLENCURICOMP_, str, enc)
+    _encode_uri_component(/[^*\-.~0-9A-Z_a-z]/, TBLENCURICOMP_, str, enc)
   end
 
   # Like URI.decode_www_form_component, except that <tt>'+'</tt> is preserved.

--- a/test/uri/test_common.rb
+++ b/test/uri/test_common.rb
@@ -152,7 +152,7 @@ class URI::TestCommon < Test::Unit::TestCase
 
   def test_encode_www_form_component
     assert_equal("%00+%21%22%23%24%25%26%27%28%29*%2B%2C-.%2F09%3A%3B%3C%3D%3E%3F%40" \
-                 "AZ%5B%5C%5D%5E_%60az%7B%7C%7D%7E",
+                 "AZ%5B%5C%5D%5E_%60az%7B%7C%7D~",
                  URI.encode_www_form_component("\x00 !\"\#$%&'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~"))
     assert_equal("%95A", URI.encode_www_form_component(
                    "\x95\x41".force_encoding(Encoding::Shift_JIS)))
@@ -204,7 +204,7 @@ class URI::TestCommon < Test::Unit::TestCase
 
   def test_encode_uri_component
     assert_equal("%00%20%21%22%23%24%25%26%27%28%29*%2B%2C-.%2F09%3A%3B%3C%3D%3E%3F%40" \
-                 "AZ%5B%5C%5D%5E_%60az%7B%7C%7D%7E",
+                 "AZ%5B%5C%5D%5E_%60az%7B%7C%7D~",
                  URI.encode_uri_component("\x00 !\"\#$%&'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~"))
     assert_equal("%95A", URI.encode_uri_component(
                    "\x95\x41".force_encoding(Encoding::Shift_JIS)))
@@ -286,6 +286,8 @@ class URI::TestCommon < Test::Unit::TestCase
     assert_equal("q=ruby&lang=en", URI.encode_www_form("q" => "ruby", "lang" => "en"))
     assert_equal("q=ruby&q=perl&lang=en", URI.encode_www_form("q" => ["ruby", "perl"], "lang" => "en"))
     assert_equal("q=ruby&q=perl&lang=en", URI.encode_www_form([["q", "ruby"], ["q", "perl"], ["lang", "en"]]))
+
+    assert_equal("special_chars=*.-_~", URI.encode_www_form("special_chars" => "*.-_~"))
   end
 
   def test_decode_www_form


### PR DESCRIPTION
Hi, first time contributing so sorry if I'm missing anything!

## Issue
- https://bugs.ruby-lang.org/issues/20690

## Heads up
This might be a breaking change, since some server-client setup might rely on `~` being encoded to `%7E` for whatever reason.
But since this is an RFC offense, the proposed implementation should be the way to go and must be enforced for future usage in web interactive applications and such.

Decoding `~` must remain the same, we just don't want to encode `~`.

## Details
This PR's change follows other escaping methods in core Ruby, such as [`CGI.escape`](https://github.com/ruby/ruby/blob/3f30c4df8c70788b065d2004dde791056d6f4162/lib/cgi/util.rb#L14-L22), [`ERB::Util.url_encode`](https://github.com/ruby/ruby/blob/3f30c4df8c70788b065d2004dde791056d6f4162/lib/erb/util.rb#L57-L59) (which actually just calls [`CGI.escapeURIComponent`](https://github.com/ruby/ruby/blob/3f30c4df8c70788b065d2004dde791056d6f4162/lib/cgi/util.rb#L41-L48) inside).

```ruby
# URI (current implementation)
irb(main):002:0> require 'uri'
=> true
irb(main):004:0> URI.encode_www_form_component("ruby~test")
=> "ruby%7Etest"

# CGI
irb(main):001:0> require 'cgi'
=> true
irb(main):003:0> CGI.escape("ruby~test")
=> "ruby~test"

# ERB
irb(main):009:0> require 'erb'
=> true
irb(main):012:0> ERB::Util.url_encode("ruby~test")
=> "ruby~test"

# Webrick
# needs webrick gem installed
[3] pry(main)> require 'webrick'
=> true
[4] pry(main)> WEBrick::HTTPUtils.escape_form("ruby~test")
=> "ruby~test"
[5] pry(main)> WEBrick::HTTPUtils.escape("ruby~test")
=> "ruby~test"
```