### PR TITLE
The local part should not contain leading or trailing dots in the EMAIL_REGEXP

### DIFF
--- a/lib/uri/mailto.rb
+++ b/lib/uri/mailto.rb
@@ -52,7 +52,7 @@ module URI
     HEADER_REGEXP  = /\A(?<hfield>(?:%\h\h|[!$'-.0-;@-Z_a-z~])*=(?:%\h\h|[!$'-.0-;@-Z_a-z~])*)(?:&\g<hfield>)*\z/
     # practical regexp for email address
     # https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
-    EMAIL_REGEXP = /\A[a-zA-Z0-9.!\#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/
+    EMAIL_REGEXP = /\A[^.][a-zA-Z0-9.!\#$%&'*+\/=?^_`{|}~-]+[^.]@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/
     # :startdoc:
 
     #

--- a/lib/uri/mailto.rb
+++ b/lib/uri/mailto.rb
@@ -52,7 +52,7 @@ module URI
     HEADER_REGEXP  = /\A(?<hfield>(?:%\h\h|[!$'-.0-;@-Z_a-z~])*=(?:%\h\h|[!$'-.0-;@-Z_a-z~])*)(?:&\g<hfield>)*\z/
     # practical regexp for email address
     # https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
-    EMAIL_REGEXP = /\A[^.][a-zA-Z0-9.!\#$%&'*+\/=?^_`{|}~-]+[^.]@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/
+    EMAIL_REGEXP = /\A(?!\.)[a-zA-Z0-9.!\#$%&'*+\/=?^_`{|}~-]+(?<!\.)@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/
     # :startdoc:
 
     #

--- a/test/uri/test_mailto.rb
+++ b/test/uri/test_mailto.rb
@@ -141,6 +141,11 @@ class URI::TestMailTo < Test::Unit::TestCase
   def test_check_to
     u = URI::MailTo.build(['joe@example.com', 'subject=Ruby'])
 
+    # Valid emails
+    u.to = 'a@valid.com'
+    assert_equal(u.to, 'a@valid.com')
+
+    # Invalid emails
     assert_raise(URI::InvalidComponentError) do
       u.to = '#1@mail.com'
     end
@@ -155,6 +160,10 @@ class URI::TestMailTo < Test::Unit::TestCase
 
     assert_raise(URI::InvalidComponentError) do
       u.to = 'hello.@invalid.email'
+    end
+
+    assert_raise(URI::InvalidComponentError) do
+      u.to = 'n.@invalid.email'
     end
   end
 

--- a/test/uri/test_mailto.rb
+++ b/test/uri/test_mailto.rb
@@ -148,6 +148,14 @@ class URI::TestMailTo < Test::Unit::TestCase
     assert_raise(URI::InvalidComponentError) do
       u.to = '@invalid.email'
     end
+
+    assert_raise(URI::InvalidComponentError) do
+      u.to = '.hello@invalid.email'
+    end
+
+    assert_raise(URI::InvalidComponentError) do
+      u.to = 'hello.@invalid.email'
+    end
   end
 
   def test_to_s


### PR DESCRIPTION
First of all, I'd like to thank all the contributors for their time and effort.

Recently, I've noticed that the EMAIL_REGEXP constant fails to handle a situations where there are leading or trailing dots in the local part of an email address. It's worth noting that while all major email providers permit the use of dots between characters, they prohibit their placement at the beginning or end of the local part.
I didn't find the exact information about the leading and trailing dots in the RFCs (5321, 5322). However, I believe it's practically useful to specify them in the regex.

Examples of an invalid email:
- `.hello@example.com`
- `hello.@example.com`