### PR TITLE
Fix wrong error message for unknown constant on `URI`

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -52,9 +52,9 @@ module URI
     elsif value = RFC2396_PARSER.regexp[const]
       warn "URI::#{const} is obsolete. Use RFC2396_PARSER.regexp[#{const.inspect}] explicitly.", uplevel: 1 if $VERBOSE
       value
-    elsif value = RFC2396_Parser.const_get(const)
+    elsif RFC2396_Parser.const_defined?(const)
       warn "URI::#{const} is obsolete. Use RFC2396_Parser::#{const} explicitly.", uplevel: 1 if $VERBOSE
-      value
+      RFC2396_Parser.const_get(const)
     else
       super
     end

--- a/test/uri/test_common.rb
+++ b/test/uri/test_common.rb
@@ -14,7 +14,8 @@ class URI::TestCommon < Test::Unit::TestCase
     orig_verbose = $VERBOSE
     $VERBOSE = nil
 
-    assert_raise(NameError) { URI::FOO }
+    e = assert_raise(NameError) { URI::FOO }
+    assert_equal(e.message, "uninitialized constant URI::FOO")
 
     assert_equal URI::ABS_URI, URI::RFC2396_PARSER.regexp[:ABS_URI]
     assert_equal URI::PATTERN, URI::RFC2396_Parser::PATTERN


### PR DESCRIPTION
`const_get` will raise if the constant is not found. Followup to https://github.com/ruby/uri/commit/1f3d3df02a0ff764e9a8a80c8d9e2c1e2d11bdce. Right now it blames `URI::RFC2396_Parser::FOO`