### PR TITLE
Remove unused files from the gem package

### DIFF
--- a/uri.gemspec
+++ b/uri.gemspec
@@ -30,8 +30,11 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  gemspec = File.basename(__FILE__)
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z 2>#{IO::NULL}`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z 2>#{IO::NULL}`.split("\x0").reject do |file|
+      (file == gemspec) || file.start_with?(*%w[bin/ test/ .github/ .gitignore Gemfile Rakefile])
+    end
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/uri.gemspec
+++ b/uri.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   gemspec = File.basename(__FILE__)
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z 2>#{IO::NULL}`.split("\x0").reject do |file|
-      (file == gemspec) || file.start_with?(*%w[bin/ test/ .github/ .gitignore Gemfile Rakefile])
+      (file == gemspec) || file.start_with?(*%w[bin/ test/ rakelib/ .github/ .gitignore Gemfile Rakefile])
     end
   end
   spec.bindir        = "exe"


### PR DESCRIPTION
There are a bunch of files in the gem package that aren't useful for downstream projects.

Let's remove these files:

```diff
- .github/dependabot.yml
- .github/workflows/gh-pages.yml
- .github/workflows/push_gem.yml
- .github/workflows/test.yml
- .gitignore
  BSDL
  COPYING
- Gemfile
  README.md
- Rakefile
- bin/console
- bin/setup
  lib/uri.rb
  lib/uri/common.rb
  lib/uri/file.rb
  lib/uri/ftp.rb
  lib/uri/generic.rb
  lib/uri/http.rb
  lib/uri/https.rb
  lib/uri/ldap.rb
  lib/uri/ldaps.rb
  lib/uri/mailto.rb
  lib/uri/rfc2396_parser.rb
  lib/uri/rfc3986_parser.rb
  lib/uri/version.rb
  lib/uri/ws.rb
  lib/uri/wss.rb
- rakelib/sync_tool.rake
- uri.gemspec
```