### PR TITLE
Restore constants like URI::REGEXP::PATTERN::IPV6ADDR

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -31,11 +31,6 @@ module URI
     if Parser == RFC2396_Parser
       const_set("REGEXP", URI::RFC2396_REGEXP)
       const_set("PATTERN", URI::RFC2396_REGEXP::PATTERN)
-      Parser.new.pattern.each_pair do |sym, str|
-        unless REGEXP::PATTERN.const_defined?(sym)
-          REGEXP::PATTERN.const_set(sym, str)
-        end
-      end
     end
 
     Parser.new.regexp.each_pair do |sym, str|

--- a/lib/uri/rfc2396_parser.rb
+++ b/lib/uri/rfc2396_parser.rb
@@ -536,4 +536,11 @@ module URI
     end
 
   end # class Parser
+
+  # Backward compatibility for URI::REGEXP::PATTERN::*
+  RFC2396_Parser.new.pattern.each_pair do |sym, str|
+    unless RFC2396_REGEXP::PATTERN.const_defined?(sym)
+      RFC2396_REGEXP::PATTERN.const_set(sym, str)
+    end
+  end
 end # module URI

--- a/test/uri/test_common.rb
+++ b/test/uri/test_common.rb
@@ -40,6 +40,7 @@ class URI::TestCommon < Test::Unit::TestCase
     assert defined?(URI::REGEXP)
     assert defined?(URI::PATTERN)
     assert defined?(URI::PATTERN::ESCAPED)
+    assert defined?(URI::REGEXP::PATTERN::IPV6ADDR)
 
     URI.parser = URI::RFC3986_PARSER
 

--- a/test/uri/test_common.rb
+++ b/test/uri/test_common.rb
@@ -10,6 +10,10 @@ class URI::TestCommon < Test::Unit::TestCase
   def teardown
   end
 
+  class Foo
+    include URI::REGEXP::PATTERN
+  end
+
   def test_fallback_constants
     orig_verbose = $VERBOSE
     $VERBOSE = nil
@@ -19,6 +23,8 @@ class URI::TestCommon < Test::Unit::TestCase
     assert_equal URI::ABS_URI, URI::RFC2396_PARSER.regexp[:ABS_URI]
     assert_equal URI::PATTERN, URI::RFC2396_Parser::PATTERN
     assert_equal URI::REGEXP, URI::RFC2396_REGEXP
+    assert_equal URI::REGEXP::PATTERN, URI::RFC2396_REGEXP::PATTERN
+    assert_equal Foo::IPV4ADDR, URI::RFC2396_REGEXP::PATTERN::IPV4ADDR
   ensure
     $VERBOSE = orig_verbose
   end


### PR DESCRIPTION
Fixed #131