### PR TITLE
Revisit deprecated test 

### DIFF
--- a/test/uri/test_common.rb
+++ b/test/uri/test_common.rb
@@ -11,7 +11,7 @@ class URI::TestCommon < Test::Unit::TestCase
   end
 
   class Foo
-    include URI::RFC2396_REGEXP::PATTERN
+    include URI::REGEXP::PATTERN
   end
 
   def test_fallback_constants

--- a/test/uri/test_common.rb
+++ b/test/uri/test_common.rb
@@ -10,23 +10,20 @@ class URI::TestCommon < Test::Unit::TestCase
   def teardown
   end
 
-  class Foo
-    include URI::REGEXP::PATTERN
-  end
+  EnvUtil.suppress_warning do
+    class Foo
+      include URI::REGEXP::PATTERN
+    end
 
-  def test_fallback_constants
-    orig_verbose = $VERBOSE
-    $VERBOSE = nil
+    def test_fallback_constants
+      assert_raise(NameError) { URI::FOO }
 
-    assert_raise(NameError) { URI::FOO }
-
-    assert_equal URI::ABS_URI, URI::RFC2396_PARSER.regexp[:ABS_URI]
-    assert_equal URI::PATTERN, URI::RFC2396_Parser::PATTERN
-    assert_equal URI::REGEXP, URI::RFC2396_REGEXP
-    assert_equal URI::REGEXP::PATTERN, URI::RFC2396_REGEXP::PATTERN
-    assert_equal Foo::IPV4ADDR, URI::RFC2396_REGEXP::PATTERN::IPV4ADDR
-  ensure
-    $VERBOSE = orig_verbose
+      assert_equal URI::ABS_URI, URI::RFC2396_PARSER.regexp[:ABS_URI]
+      assert_equal URI::PATTERN, URI::RFC2396_Parser::PATTERN
+      assert_equal URI::REGEXP, URI::RFC2396_REGEXP
+      assert_equal URI::REGEXP::PATTERN, URI::RFC2396_REGEXP::PATTERN
+      assert_equal Foo::IPV4ADDR, URI::RFC2396_REGEXP::PATTERN::IPV4ADDR
+    end
   end
 
   def test_parser_switch


### PR DESCRIPTION
We need to test with `include URI::REGEXP::PATTERN` again.