### PR TITLE
Suppress deprecate warning of test class (retry)

### DIFF
--- a/test/uri/test_common.rb
+++ b/test/uri/test_common.rb
@@ -12,10 +12,13 @@ class URI::TestCommon < Test::Unit::TestCase
 
   EnvUtil.suppress_warning do
     class Foo
+      # Intentionally use `URI::REGEXP`, which is for the compatibility
       include URI::REGEXP::PATTERN
     end
+  end
 
-    def test_fallback_constants
+  def test_fallback_constants
+    EnvUtil.suppress_warning do
       assert_raise(NameError) { URI::FOO }
 
       assert_equal URI::ABS_URI, URI::RFC2396_PARSER.regexp[:ABS_URI]


### PR DESCRIPTION
A follow-up to bd2e4be9d0fa4937efa7811a999f5820ea868a9f

Also, leave a comment that the use of `URI::REGEXP` is intentional