### PR TITLE
Fix the mention to removed `URI.escape/URI::Escape`

### DIFF
--- a/lib/uri/file.rb
+++ b/lib/uri/file.rb
@@ -47,7 +47,7 @@ module URI
     #       :path => '/ruby/src'})
     #     uri2.to_s  # => "file://host.example.com/ruby/src"
     #
-    #     uri3 = URI::File.build({:path => URI::escape('/path/my file.txt')})
+    #     uri3 = URI::File.build({:path => URI::RFC2396_PARSER.escape('/path/my file.txt')})
     #     uri3.to_s  # => "file:///path/my%20file.txt"
     #
     def self.build(args)

--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -73,7 +73,7 @@ module URI
     #
     # At first, tries to create a new URI::Generic instance using
     # URI::Generic::build. But, if exception URI::InvalidComponentError is raised,
-    # then it does URI::Escape.escape all URI components and tries again.
+    # then it does URI::RFC2396_PARSER.escape all URI components and tries again.
     #
     def self.build2(args)
       begin


### PR DESCRIPTION
This was removed by #9.