### PR TITLE
Add parsing without raising exceptions

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -204,8 +204,8 @@ module URI
   # It's recommended to first ::escape string +uri+
   # if it may contain invalid URI characters.
   #
-  def self.parse(uri)
-    DEFAULT_PARSER.parse(uri)
+  def self.parse(uri, exception: true)
+    DEFAULT_PARSER.parse(uri, exception: exception)
   end
 
   # Merges the given URI strings +str+

--- a/lib/uri/rfc2396_parser.rb
+++ b/lib/uri/rfc2396_parser.rb
@@ -117,7 +117,7 @@ module URI
     attr_reader :regexp
 
     # Returns a split URI against +regexp[:ABS_URI]+.
-    def split(uri)
+    def split(uri, exception: true)
       case uri
       when ''
         # null uri
@@ -139,10 +139,14 @@ module URI
         # server        = [ [ userinfo "@" ] hostport ]
 
         if !scheme
+          return unless exception
+
           raise InvalidURIError,
             "bad URI (absolute but no scheme): #{uri}"
         end
         if !opaque && (!path && (!host && !registry))
+          return unless exception
+
           raise InvalidURIError,
             "bad URI (absolute but no path): #{uri}"
         end
@@ -173,6 +177,8 @@ module URI
         # server        = [ [ userinfo "@" ] hostport ]
 
       else
+        return unless exception
+
         raise InvalidURIError, "bad URI (is not URI?): #{uri}"
       end
 
@@ -206,8 +212,11 @@ module URI
     #   p.parse("ldap://ldap.example.com/dc=example?user=john")
     #   #=> #<URI::LDAP ldap://ldap.example.com/dc=example?user=john>
     #
-    def parse(uri)
-      URI.for(*self.split(uri), self)
+    def parse(uri, exception: true)
+      scheme = self.split(uri, exception: exception)
+      return if scheme.nil?
+
+      URI.for(*scheme, self)
     end
 
     #

--- a/test/uri/test_parser.rb
+++ b/test/uri/test_parser.rb
@@ -92,6 +92,17 @@ class URI::TestParser < Test::Unit::TestCase
     end
   end
 
+  def test_split_without_exception
+    assert_equal(["http", nil, "example.com", nil, nil, "", nil, nil, nil], URI.split("http://example.com"))
+    assert_equal(["http", nil, "[0::0]", nil, nil, "", nil, nil, nil], URI.split("http://[0::0]"))
+    assert_equal([nil, nil, "example.com", nil, nil, "", nil, nil, nil], URI.split("//example.com"))
+    assert_equal([nil, nil, "[0::0]", nil, nil, "", nil, nil, nil], URI.split("//[0::0]"))
+
+    assert_equal(["a", nil, nil, nil, nil, "", nil, nil, nil], URI.split("a:"))
+    assert_nil  URI.parse("::", exception: false)
+    assert_nil URI.parse("foo@example:foo", exception: false)
+  end
+
   def test_rfc2822_parse_relative_uri
     pre = ->(length) {
       " " * length + "\0"


### PR DESCRIPTION
Similar to what Integer(value, exception: false) does but for
URI.parse(value, exception: false).

The change is implemented for the default parser (RFC3986) and also RFC2396.
The goal is to allow parsing invalid/user input without having to have control flow via exceptions or by having to wrap URI.parse in a method per project.

This change can be tried via`~/.rubies/ruby-master/bin/ruby -r 'uri' -e 'URI.parse("https://example.com/\[\]", exception: false)'` and `~/.rubies/ruby-master/bin/ruby -r 'uri' -e
'URI.parse("https://example.com/\[\]")'` respectively (or with`exception: true`) and is also covered by tests. Or by just changing the tests to observe the behavior