### PR TITLE
Use a fully qualified name in warning messages

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -49,10 +49,10 @@ module URI
       warn "URI::REGEXP is obsolete. Use URI::RFC2396_REGEXP explicitly.", uplevel: 1 if $VERBOSE
       URI::RFC2396_REGEXP
     elsif value = RFC2396_PARSER.regexp[const]
-      warn "URI::#{const} is obsolete. Use RFC2396_PARSER.regexp[#{const.inspect}] explicitly.", uplevel: 1 if $VERBOSE
+      warn "URI::#{const} is obsolete. Use URI::RFC2396_PARSER.regexp[#{const.inspect}] explicitly.", uplevel: 1 if $VERBOSE
       value
     elsif value = RFC2396_Parser.const_get(const)
-      warn "URI::#{const} is obsolete. Use RFC2396_Parser::#{const} explicitly.", uplevel: 1 if $VERBOSE
+      warn "URI::#{const} is obsolete. Use URI::RFC2396_Parser::#{const} explicitly.", uplevel: 1 if $VERBOSE
       value
     else
       super


### PR DESCRIPTION
Currently, some warning messages don't contain a `URI` like the following.

```ruby
warning: URI::ABS_URI is obsolete. Use RFC2396_PARSER.regexp[:ABS_URI] explicitly.
```

But, without `URI` prefix, the suggested value doesn't work. So I think we should use a fully qualified name to avoid confusion.