### PR TITLE
Add method base_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ uri.host      #=> "foo.com"
 uri.path      #=> "/posts"
 uri.query     #=> "id=30&limit=5"
 uri.fragment  #=> "time=1305298413"
+uri.base_url  #=> "http://foo.com"
 
 uri.to_s      #=> "http://foo.com/posts?id=30&limit=5#time=1305298413"
 ```

--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -1576,5 +1576,13 @@ module URI
       }
       true
     end
+
+    # Returns the base url of the URI.
+    #
+    #   URI("http://foo.com/one/two?param1=value1").base_url #=> "http://foo.com"
+    #
+    def base_url
+      "#{scheme}://#{hostname}"
+    end
   end
 end

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -1078,4 +1078,8 @@ class URI::TestGeneric < Test::Unit::TestCase
     yield h
   end
 
+  def test_base_url
+    url = URI.parse('http://test.example.com/one/two/base_url?param1=value')
+    assert_equal 'http://test.example.com', url.base_url
+  end
 end


### PR DESCRIPTION
Often when I use **URI(url)** with path and query, I have to get base url (e.g. http://test.example.com) and I have to do this:

- `uri = URI("http://test.example.com/one/two/base_url?param1=value")`

- `"#{uri.scheme}://#{uri.host}"`

I suggest adding  **base_url** method instead, which will return - **http://test.example.com**