### PR TITLE
Switch a parsing behavior completely when switching a parser

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -30,6 +30,9 @@ module URI
     remove_const(:Parser) if defined?(::URI::Parser)
     const_set("Parser", parser.class)
 
+    remove_const(:PARSER) if defined?(::URI::PARSER)
+    const_set("PARSER", parser)
+
     remove_const(:REGEXP) if defined?(::URI::REGEXP)
     remove_const(:PATTERN) if defined?(::URI::PATTERN)
     if Parser == RFC2396_Parser
@@ -195,7 +198,7 @@ module URI
   #    ["fragment", "top"]]
   #
   def self.split(uri)
-    DEFAULT_PARSER.split(uri)
+    PARSER.split(uri)
   end
 
   # Returns a new \URI object constructed from the given string +uri+:
@@ -209,7 +212,7 @@ module URI
   # if it may contain invalid URI characters.
   #
   def self.parse(uri)
-    DEFAULT_PARSER.parse(uri)
+    PARSER.parse(uri)
   end
 
   # Merges the given URI strings +str+
@@ -265,7 +268,7 @@ module URI
   #
   def self.extract(str, schemes = nil, &block) # :nodoc:
     warn "URI.extract is obsolete", uplevel: 1 if $VERBOSE
-    DEFAULT_PARSER.extract(str, schemes, &block)
+    PARSER.extract(str, schemes, &block)
   end
 
   #
@@ -302,7 +305,7 @@ module URI
   #
   def self.regexp(schemes = nil)# :nodoc:
     warn "URI.regexp is obsolete", uplevel: 1 if $VERBOSE
-    DEFAULT_PARSER.make_regexp(schemes)
+    PARSER.make_regexp(schemes)
   end
 
   TBLENCWWWCOMP_ = {} # :nodoc:

--- a/test/uri/test_common.rb
+++ b/test/uri/test_common.rb
@@ -31,12 +31,14 @@ class URI::TestCommon < Test::Unit::TestCase
 
   def test_parser_switch
     assert_equal(URI::Parser, URI::RFC3986_Parser)
+    assert_equal(URI::PARSER, URI::RFC3986_PARSER)
     refute defined?(URI::REGEXP)
     refute defined?(URI::PATTERN)
 
     URI.parser = URI::RFC2396_PARSER
 
     assert_equal(URI::Parser, URI::RFC2396_Parser)
+    assert_equal(URI::PARSER, URI::RFC2396_PARSER)
     assert defined?(URI::REGEXP)
     assert defined?(URI::PATTERN)
     assert defined?(URI::PATTERN::ESCAPED)
@@ -45,6 +47,7 @@ class URI::TestCommon < Test::Unit::TestCase
     URI.parser = URI::RFC3986_PARSER
 
     assert_equal(URI::Parser, URI::RFC3986_Parser)
+    assert_equal(URI::PARSER, URI::RFC3986_PARSER)
     refute defined?(URI::REGEXP)
     refute defined?(URI::PATTERN)
   ensure


### PR DESCRIPTION
Currently, some methods' behavior(e.g. `URI.parse`) don't change when switching a parser. This is because some methods use `DEFAULT_PARSER`, but `parser=` doesn't change `DEFAULT_PARSER`.

This PR introduces a constant to keep a parser's instance and change it when switching a parser. Also, change to use it in methods.