### PR TITLE
Replace reference to the obsolete URI.escape with URI::RFC2396_PARSER.escape

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -205,7 +205,7 @@ module URI
   #   URI.parse('http://john.doe@www.example.com:123/forum/questions/?tag=networking&order=newest#top')
   #   # => #<URI::HTTP http://john.doe@www.example.com:123/forum/questions/?tag=networking&order=newest#top>
   #
-  # It's recommended to first ::escape string +uri+
+  # It's recommended to first URI::RFC2396_PARSER.escape string +uri+
   # if it may contain invalid URI characters.
   #
   def self.parse(uri)


### PR DESCRIPTION
I noticed that the documentation for `URI.parse` still referred to the deprecated `URI.escape`. Following the same approach as #146, this pull request replaces it with an explicit reference to `URI::RFC2396_PARSER.escape`.