### PR TITLE
Fix the message for unexpected argument

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -126,9 +126,9 @@ module URI
           end
         end
       else
-        component = self.class.component rescue ::URI::Generic::COMPONENT
+        component = self.component rescue ::URI::Generic::COMPONENT
         raise ArgumentError,
-        "expected Array of or Hash of components of #{self.class} (#{component.join(', ')})"
+              "expected Array of or Hash of components of #{self} (#{component.join(', ')})"
       end
 
       tmp << nil

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -868,6 +868,19 @@ class URI::TestGeneric < Test::Unit::TestCase
     assert_equal("http://[::1]/bar/baz", u.to_s)
     assert_equal("[::1]", u.host)
     assert_equal("::1", u.hostname)
+
+    assert_raise_with_message(ArgumentError, /URI::Generic/) {
+      URI::Generic.build(nil)
+    }
+
+    c = Class.new(URI::Generic) do
+      def self.component; raise; end
+    end
+    expected = /\(#{URI::Generic::COMPONENT.join(', ')}\)/
+    message = "fallback to URI::Generic::COMPONENT if component raised"
+    assert_raise_with_message(ArgumentError, expected, message) {
+      c.build(nil)
+    }
   end
 
   def test_build2


### PR DESCRIPTION
Use just `self` instead of `self.class`, in `URI::Generic.build`. Since this is a class method, `self.class` is always `Class` even in inherited sub classes, and does not have `#component` method.