### PR TITLE
More checks in `EMAIL_REGEXP`

### DIFF
--- a/lib/uri/mailto.rb
+++ b/lib/uri/mailto.rb
@@ -52,7 +52,7 @@ module URI
     HEADER_REGEXP  = /\A(?<hfield>(?:%\h\h|[!$'-.0-;@-Z_a-z~])*=(?:%\h\h|[!$'-.0-;@-Z_a-z~])*)(?:&\g<hfield>)*\z/
     # practical regexp for email address
     # https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
-    EMAIL_REGEXP = /\A(?!\.)[a-zA-Z0-9.!\#$%&'*+\/=?^_`{|}~-]+(?<!\.)@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/
+    EMAIL_REGEXP = /\A(?!\.)(?!.*\.{2})[a-zA-Z0-9.!\#$%&'*+\/=?^_`{|}~-]+(?<!\.)@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/
     # :startdoc:
 
     #

--- a/test/uri/test_mailto.rb
+++ b/test/uri/test_mailto.rb
@@ -165,6 +165,45 @@ class URI::TestMailTo < Test::Unit::TestCase
     assert_raise(URI::InvalidComponentError) do
       u.to = 'n.@invalid.email'
     end
+
+    # Invalid host emails
+    assert_raise(URI::InvalidComponentError) do
+      u.to = 'a@.invalid.email'
+    end
+
+    assert_raise(URI::InvalidComponentError) do
+      u.to = 'a@invalid.email.'
+    end
+
+    assert_raise(URI::InvalidComponentError) do
+      u.to = 'a@invalid..email'
+    end
+
+    assert_raise(URI::InvalidComponentError) do
+      u.to = 'a@-invalid.email'
+    end
+
+    assert_raise(URI::InvalidComponentError) do
+      u.to = 'a@invalid-.email'
+    end
+
+    assert_raise(URI::InvalidComponentError) do
+      u.to = 'a@invalid.-email'
+    end
+
+    assert_raise(URI::InvalidComponentError) do
+      u.to = 'a@invalid.email-'
+    end
+
+    u.to = 'a@'+'invalid'.ljust(63, 'd')+'.email'
+    assert_raise(URI::InvalidComponentError) do
+      u.to = 'a@'+'invalid'.ljust(64, 'd')+'.email'
+    end
+
+    u.to = 'a@invalid.'+'email'.rjust(63, 'e')
+    assert_raise(URI::InvalidComponentError) do
+      u.to = 'a@invalid.'+'email'.rjust(64, 'e')
+    end
   end
 
   def test_to_s

--- a/test/uri/test_mailto.rb
+++ b/test/uri/test_mailto.rb
@@ -166,6 +166,10 @@ class URI::TestMailTo < Test::Unit::TestCase
       u.to = 'n.@invalid.email'
     end
 
+    assert_raise(URI::InvalidComponentError) do
+      u.to = 'n..t@invalid.email'
+    end
+
     # Invalid host emails
     assert_raise(URI::InvalidComponentError) do
       u.to = 'a@.invalid.email'


### PR DESCRIPTION
Successive dots are prohibited in RFC5322.
