### PR TITLE
Fix overly permissive regular expression range

### DIFF
--- a/lib/uri/mailto.rb
+++ b/lib/uri/mailto.rb
@@ -176,7 +176,7 @@ module URI
 
       v.split(/[,;]/).each do |addr|
         # check url safety as path-rootless
-        if /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*\z/ !~ addr
+        if /\A(?:%\h\h|[!$&-.0-9:;=@-Z_a-z~])*\z/ !~ addr
           raise InvalidComponentError,
             "an address in 'to' is invalid as URI #{addr.dump}"
         end


### PR DESCRIPTION
Fix the problem, we need to replace the overly broad range `0-;` in the regular expression with the correct set of allowed characters. The intention is likely to allow digits (`0-9`) and possibly the characters `:` and `;` if they are explicitly required. If only digits are intended, replace `0-;` with `0-9`. If `:` and `;` are also required, list them explicitly outside the range, e.g., `0-9:;`. The fix should be applied to the regular expression in the `check_to` method on line 179 of `lib/uri/mailto.rb`. No new imports or methods are required.

### References
[Improper Neutralization of Special Elements used in a Command in Shell-quote](https://github.com/advisories/GHSA-g4rg-993r-mgx7)
[shell-quote](https://wh0.github.io/2021/10/28/shell-quote-rce-exploiting.html)
[no-obscure-range](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-obscure-range.html)
[The regex [,-.]](https://pboyd.io/posts/comma-dash-dot/)