### PR TITLE
Add `irb` to the Gemfile to fix the warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
+  gem "irb"
   gem "bundler"
   gem "rake"
   gem "test-unit"


### PR DESCRIPTION
Currently, using `bin/console` shows the following warning.

```
./bin/console:13: warning: irb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add irb to your Gemfile or gemspec to silence this warning.
```

This PR adds `irb` to fix it.