### PR TITLE
Use generic version number to VERSION

### DIFF
--- a/lib/uri/version.rb
+++ b/lib/uri/version.rb
@@ -1,6 +1,6 @@
 module URI
   # :stopdoc:
-  VERSION_CODE = '010004'.freeze
-  VERSION = VERSION_CODE.scan(/../).collect{|n| n.to_i}.join('.').freeze
+  VERSION = '1.0.4'.freeze
+  VERSION_CODE = VERSION.split('.').map{|s| s.rjust(2, '0')}.join.freeze
   # :startdoc:
 end


### PR DESCRIPTION
The current `VERSION_CODE` is not useful for version bump tool like https://github.com/gregorym/bump