### PR TITLE
Allow global wildcard as a no_proxy entry

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -1568,9 +1568,13 @@ module URI
     end
 
     def self.use_proxy?(hostname, addr, port, no_proxy) # :nodoc:
+      no_proxy_entries = no_proxy.scan(/([^:,\s]+)(?::(\d+))?/)
+      return false if no_proxy_entries.any? { |entry, _| entry == '*' }
+
       hostname = hostname.downcase
       dothostname = ".#{hostname}"
-      no_proxy.scan(/([^:,\s]+)(?::(\d+))?/) {|p_host, p_port|
+
+      no_proxy_entries.each {|p_host, p_port|
         if !p_port || port == p_port.to_i
           if p_host.start_with?('.')
             return false if hostname.end_with?(p_host.downcase)

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -965,6 +965,9 @@ class URI::TestGeneric < Test::Unit::TestCase
       assert_equal(URI('http://127.0.0.1:8080'), URI("http://example.org/").find_proxy(env))
       assert_nil(URI("http://www.example.org/").find_proxy(env))
     }
+    with_proxy_env('http_proxy'=>'http://127.0.0.1:8080', 'no_proxy'=>'*') {|env|
+      assert_nil(URI("http://www.example.org/").find_proxy(env))
+    }
   ensure
     IPSocket.singleton_class.class_eval do
       undef getaddress
@@ -1008,8 +1011,10 @@ class URI::TestGeneric < Test::Unit::TestCase
       ['example.com', nil, 80, '', true],
       ['example.com', nil, 80, 'example.com:80', false],
       ['example.com', nil, 80, 'example.org,example.com:80,example.net', false],
+      ['example.com', nil, 80, 'example.org,*', false],
       ['foo.example.com', nil, 80, 'example.com', false],
       ['foo.example.com', nil, 80, '.example.com', false],
+      ['foo.example.com', nil, 80, '*.example.com', true],
       ['example.com', nil, 80, '.example.com', true],
       ['xample.com', nil, 80, '.example.com', true],
       ['fooexample.com', nil, 80, '.example.com', true],
@@ -1020,6 +1025,7 @@ class URI::TestGeneric < Test::Unit::TestCase
       ['127.0.0.1', '127.0.0.1', 80, '10.224.0.0/22', true],
       ['10.224.1.1', '10.224.1.1', 80, '10.224.1.1', false],
       ['10.224.1.1', '10.224.1.1', 80, '10.224.0.0/22', false],
+      ['10.224.1.1', '10.224.1.1', 80, '*', false],
     ].each do |hostname, addr, port, no_proxy, expected|
       assert_equal expected, URI::Generic.use_proxy?(hostname, addr, port, no_proxy),
         "use_proxy?('#{hostname}', '#{addr}', #{port}, '#{no_proxy}')"


### PR DESCRIPTION
It seems that Ruby is one of the language that doesn't accept the global wildcard `*` as a `no_proxy` entry to match all hosts (cf. [Gitlab article about no_proxy](https://about.gitlab.com/blog/we-need-to-talk-no-proxy/#no_proxy-format)).

This Pull Request resolves this.

Also, I just wanted to point out that the wildcard around or next to other caracters is not an accepted value except for [former-IE user](https://learn.microsoft.com/en-us/previous-versions/troubleshoot/browsers/connectivity-navigation/use-proxy-servers-with-ie) as documented on [Mozillazine](https://kb.mozillazine.org/Network.proxy.no_proxies_on). For this, I don't really know what to do, but this can be part of another PR.