### PR TITLE
Move URI::HTTP#authority to URI::Generic

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -747,6 +747,45 @@ module URI
       port
     end
 
+    #
+    # == Description
+    #
+    # Returns the authority of the URI, as defined in
+    # https://www.rfc-editor.org/rfc/rfc3986#section-3.2.
+    #
+    #   authority = [ userinfo "@" ] host [ ":" port ]
+    #
+    # Returns an empty string if no authority is present.
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   URI::HTTP.build(host: 'www.example.com', path: '/foo/bar').authority
+    #   #=> "www.example.com"
+    #   URI::HTTP.build(host: 'www.example.com', port: 8000, path: '/foo/bar').authority
+    #   #=> "www.example.com:8000"
+    #   URI::HTTP.build(host: 'www.example.com', port: 80, path: '/foo/bar').authority
+    #   #=> "www.example.com"
+    #   URI::HTTP.build(host: 'www.example.com', userinfo: 'user:password').authority
+    #   #=> "user:password@www.example.com"
+    #
+    def authority
+      str = ''.dup
+      if self.userinfo
+        str << self.userinfo
+        str << '@'
+      end
+      if @host
+        str << @host
+      end
+      if @port && @port != self.default_port
+        str << ':'
+        str << @port.to_s
+      end
+      str
+    end
+
     def check_registry(v) # :nodoc:
       raise InvalidURIError, "cannot set registry"
     end
@@ -1365,17 +1404,7 @@ module URI
         if @host || %w[file postgres].include?(@scheme)
           str << '//'
         end
-        if self.userinfo
-          str << self.userinfo
-          str << '@'
-        end
-        if @host
-          str << @host
-        end
-        if @port && @port != self.default_port
-          str << ':'
-          str << @port.to_s
-        end
+        str << self.authority
         if (@host || @port) && !@path.empty? && !@path.start_with?('/')
           str << '/'
         end

--- a/lib/uri/http.rb
+++ b/lib/uri/http.rb
@@ -96,27 +96,6 @@ module URI
     #
     # == Description
     #
-    # Returns the authority for an HTTP uri, as defined in
-    # https://www.rfc-editor.org/rfc/rfc3986#section-3.2.
-    #
-    #
-    # Example:
-    #
-    #     URI::HTTP.build(host: 'www.example.com', path: '/foo/bar').authority #=> "www.example.com"
-    #     URI::HTTP.build(host: 'www.example.com', port: 8000, path: '/foo/bar').authority #=> "www.example.com:8000"
-    #     URI::HTTP.build(host: 'www.example.com', port: 80, path: '/foo/bar').authority #=> "www.example.com"
-    #
-    def authority
-      if port == default_port
-        host
-      else
-        "#{host}:#{port}"
-      end
-    end
-
-    #
-    # == Description
-    #
     # Returns the origin for an HTTP uri, as defined in
     # https://www.rfc-editor.org/rfc/rfc6454.
     #

--- a/test/uri/test_http.rb
+++ b/test/uri/test_http.rb
@@ -73,8 +73,8 @@ class URI::TestHTTP < Test::Unit::TestCase
     assert_equal('a.b.c', URI.parse('http://a.b.c/').authority)
     assert_equal('a.b.c:8081', URI.parse('http://a.b.c:8081/').authority)
     assert_equal('a.b.c', URI.parse('http://a.b.c:80/').authority)
+    assert_equal('userinfo@a.b.c', URI.parse('https://userinfo@a.b.c/').authority)
   end
-
 
   def test_origin
     assert_equal('http://a.b.c', URI.parse('http://a.b.c/').origin)


### PR DESCRIPTION
`URI::HTTP#authority` should belong to `URI::Generic` since the concept of an authority isn't specific to http or https URIs: https://datatracker.ietf.org/doc/html/rfc3986#section-3.2

However, `URI::Generic#authority` was recently taken in commit https://github.com/ruby/uri/commit/6c6449e15ffae7027bfe83134f0419f682e0b1ad, where it returns a list of subcomponents of the authority. This has made into v1.0.4 (2025-10-07).

Although it has a public visibility, it seems to have been intended for internal use, as there are no direct tests for it and no mention in the GitHub release notes. If it's not too late, I'd like to rename it to something else. In this PR, I've renamed it to "authority_components".

This PR also fixes `URI::HTTP#authority` (now `URI::Generic#authority`) skipping the userinfo part.

@nobu @HoneyryderChuck What do you think?
