### PR TITLE
Avoid to call obsolete methods

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -299,8 +299,8 @@ module URI
   #   # => ["http://foo.example.com/bla", "mailto:test@example.com"]
   #
   def self.extract(str, schemes = nil, &block) # :nodoc:
-    warn "URI.extract is obsolete", uplevel: 1 if $VERBOSE
-    PARSER.extract(str, schemes, &block)
+    warn "URI.extract is obsolete. Please use URI::RFC2396_PARSER.extract instead.", uplevel: 1 if $VERBOSE
+    URI::RFC2396_PARSER.extract(str, schemes, &block)
   end
 
   #
@@ -336,8 +336,8 @@ module URI
   #   end
   #
   def self.regexp(schemes = nil)# :nodoc:
-    warn "URI.regexp is obsolete", uplevel: 1 if $VERBOSE
-    PARSER.make_regexp(schemes)
+    warn "URI.regexp is obsolete. Please use URI::RFC2396_PARSER.make_regexp instead.", uplevel: 1 if $VERBOSE
+    RFC2396_PARSER.make_regexp(schemes)
   end
 
   TBLENCWWWCOMP_ = {} # :nodoc:


### PR DESCRIPTION
Currently, when a user call `URI.regexp`, two messages are shown.

```
$ ruby -w -e "require 'uri'; URI.regexp('https')"
-e:1: warning: URI.regexp is obsolete
uri-1.1.1/lib/uri/common.rb:340: warning: URI::RFC3986_PARSER.make_regexp is obsolete. Use URI::RFC2396_PARSER.make_regexp explicitly.
```

I think this is a bit redundant.

I updated to call `URI::RFC2396_PARSER.make_regexp` directly since only RFC2396 parser supports `.make_regexp`.

I also updated the message to indicate that `URI::RFC2396.make_regexp` must be used if you still want to use `URI.regexp`.

This issue also exists in `URI.extract`, so I applied the same fix there.