### PR TITLE
uri: align Generic parser default with URI.parser

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -158,7 +158,7 @@ module URI
     # +fragment+::
     #   Part of the URI after '#' character.
     # +parser+::
-    #   Parser for internal use [URI::DEFAULT_PARSER by default].
+    #   Parser for internal use [URI::PARSER by default].
     # +arg_check+::
     #   Check arguments [false by default].
     #
@@ -171,7 +171,7 @@ module URI
                    path, opaque,
                    query,
                    fragment,
-                   parser = DEFAULT_PARSER,
+                   parser = PARSER,
                    arg_check = false)
       @scheme = nil
       @user = nil
@@ -182,7 +182,7 @@ module URI
       @query = nil
       @opaque = nil
       @fragment = nil
-      @parser = parser == DEFAULT_PARSER ? nil : parser
+      @parser = parser == PARSER ? nil : parser
 
       if arg_check
         self.scheme = scheme
@@ -284,13 +284,13 @@ module URI
 
     # Returns the parser to be used.
     #
-    # Unless the +parser+ is defined, DEFAULT_PARSER is used.
+    # Unless the +parser+ is defined, PARSER is used.
     #
     def parser
       if !defined?(@parser) || !@parser
-        DEFAULT_PARSER
+        PARSER
       else
-        @parser || DEFAULT_PARSER
+        @parser || PARSER
       end
     end
 

--- a/test/uri/test_parser.rb
+++ b/test/uri/test_parser.rb
@@ -49,6 +49,32 @@ class URI::TestParser < Test::Unit::TestCase
     URI.parser = URI::DEFAULT_PARSER
   end
 
+  def test_generic_build_uses_current_parser
+    URI.parser = URI::RFC2396_PARSER
+
+    uri = URI::Generic.build(['http', nil, 'example.com', nil, nil, '/', nil, nil, nil])
+    assert_equal(URI::RFC2396_Parser, uri.parser.class)
+
+    URI.parser = URI::RFC3986_PARSER
+    uri = URI::Generic.build(['http', nil, 'example.com', nil, nil, '/', nil, nil, nil])
+    assert_equal(URI::RFC3986_Parser, uri.parser.class)
+  ensure
+    URI.parser = URI::DEFAULT_PARSER
+  end
+
+  def test_generic_new_uses_current_parser_when_omitted
+    URI.parser = URI::RFC2396_PARSER
+
+    uri = URI::Generic.new('http', nil, 'example.com', nil, nil, '/', nil, nil, nil)
+    assert_equal(URI::RFC2396_Parser, uri.parser.class)
+
+    URI.parser = URI::RFC3986_PARSER
+    uri = URI::Generic.new('http', nil, 'example.com', nil, nil, '/', nil, nil, nil)
+    assert_equal(URI::RFC3986_Parser, uri.parser.class)
+  ensure
+    URI.parser = URI::DEFAULT_PARSER
+  end
+
   def test_parse_query_pct_encoded
     assert_equal('q=%32!$&-/?.09;=:@AZ_az~', URI.parse('https://www.example.com/search?q=%32!$&-/?.09;=:@AZ_az~').query)
     assert_raise(URI::InvalidURIError) { URI.parse('https://www.example.com/search?q=%XX') }


### PR DESCRIPTION
This pull request updates the default URI parser logic in the `URI::Generic` class to use the current global parser (`URI::PARSER`) instead of the previous constant (`URI::DEFAULT_PARSER`).

It also adds tests to ensure that both `build` and `new` methods respect the global parser setting when the parser argument is omitted.