### PR TITLE
Check whether a const is defined before getting it

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -54,7 +54,7 @@ module URI
     elsif value = RFC2396_PARSER.regexp[const]
       warn "URI::#{const} is obsolete. Use URI::RFC2396_PARSER.regexp[#{const.inspect}] explicitly.", uplevel: 1 if $VERBOSE
       value
-    elsif value = RFC2396_Parser.const_get(const)
+    elsif RFC2396_Parser.const_defined?(const) && value = RFC2396_Parser.const_get(const)
       warn "URI::#{const} is obsolete. Use URI::RFC2396_Parser::#{const} explicitly.", uplevel: 1 if $VERBOSE
       value
     else

--- a/test/uri/test_common.rb
+++ b/test/uri/test_common.rb
@@ -19,7 +19,8 @@ class URI::TestCommon < Test::Unit::TestCase
 
   def test_fallback_constants
     EnvUtil.suppress_warning do
-      assert_raise(NameError) { URI::FOO }
+      e = assert_raise(NameError) { URI::FOO }
+      assert_equal(e.message, "uninitialized constant URI::FOO")
 
       assert_equal URI::ABS_URI, URI::RFC2396_PARSER.regexp[:ABS_URI]
       assert_equal URI::PATTERN, URI::RFC2396_Parser::PATTERN


### PR DESCRIPTION
Currently, if an unexist const was specified, a namespace in an error message is `URI::RFC2396_Parser`.

```
$ ruby -w -r "uri" -e "puts URI::Mailto"
lib/uri/common.rb:57:in 'Module#const_get': uninitialized constant URI::RFC2396_Parser::Mailto (NameError)

    elsif value = RFC2396_Parser.const_get(const)
```

I think this is misleading a little. This PR fixes to show a correct namespace.

```
$ ruby -w -r "uri" -e "puts URI::Mailto"
lib/uri/common.rb:61:in 'URI.const_missing': uninitialized constant URI::Mailto (NameError)
Did you mean?  URI::MailTo
```