### PR TITLE
Remove unsued `RFC2396_REGEXP` include

### DIFF
--- a/lib/uri/mailto.rb
+++ b/lib/uri/mailto.rb
@@ -15,8 +15,6 @@ module URI
   # RFC6068, the mailto URL scheme.
   #
   class MailTo < Generic
-    include RFC2396_REGEXP
-
     # A Default port of nil for URI::MailTo.
     DEFAULT_PORT = nil
 


### PR DESCRIPTION
`MailTo` used constants under `REGEXP::PATTERN` before. But, they removed by 3fdc4b6 and unused them now.