### PR TITLE
Constrain RDoc below 8 for JRuby CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,12 @@ group :development do
   gem "irb"
   gem "bundler"
   gem "rake"
+  if RUBY_ENGINE == 'jruby'
+    # RDoc 8 pulls in RBS 4, which attempts to build a native extension on JRuby.
+    gem 'rdoc', '< 8'
+  else
+    gem 'rdoc'
+  end
   gem "test-unit"
   gem "test-unit-ruby-core", ">= 1.0.7"
 end


### PR DESCRIPTION
Quoting https://github.com/ruby/erb/pull/122

> RDoc 8 resolves RBS 4, which attempts to build a native extension under JRuby and breaks the Dependabot test workflow before tests run.
> 
> This caps the development RDoc dependency below 8 so the JRuby matrix can install dependencies again while keeping RDoc coverage enabled.