### PR TITLE
Reduce base-path ".." removal in merge_path to a linear pass

### DIFF
--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -1021,9 +1021,21 @@ module URI
 
       # RFC2396, Section 5.2, 6), a)
       base_path << '' if base_path.last == '..'
-      while i = base_path.index('..')
-        base_path.slice!(i - 1, 2)
+      # Remove "<segment>/.." pairs in a single left-to-right pass (O(n)).
+      # This deliberately differs from the relative-path stack handling
+      # below: a leading ".." (one with no preceding segment left to
+      # cancel) discards the whole base path, reproducing the previous
+      # index/slice! implementation exactly.
+      reduced = []
+      base_path.each do |seg|
+        if seg == '..'
+          break if reduced.empty?
+          reduced.pop
+        else
+          reduced << seg
+        end
       end
+      base_path = reduced
 
       if (first = rel_path.first) and first.empty?
         base_path.clear

--- a/test/uri/test_generic.rb
+++ b/test/uri/test_generic.rb
@@ -278,6 +278,43 @@ class URI::TestGeneric < Test::Unit::TestCase
     assert_equal(u0, u1)
   end
 
+  def test_merge_path_dot_dot_removal
+    # Base-path ".." removal (RFC2396 5.2 6a) is handled by a single
+    # left-to-right pass. These lock in the exact, historically observed
+    # semantics, which differ from the relative-path stack: a leading ".."
+    # (or a ".." exposed as leading after earlier cancellations) discards
+    # the remaining base path rather than being kept.
+    {
+      'http://h/a/../../b'      => { 'x' => 'http://h/x' },
+      'http://h/../a'           => { 'x' => 'http://h/x' },
+      'http://h/a/..'           => { 'x' => 'http://h/x' },
+      'http://h/../x'           => { 'y' => 'http://h/y' },
+      'http://h/foo/bar/..'     => { './' => 'http://h/foo/' },
+      'http://h/foo/bar/../..'  => { './' => 'http://h/' },
+      'http://h/a/b/c'          => {
+        '../../g'       => 'http://h/g',
+        '../../../g'    => 'http://h/g',
+        '../../../../g' => 'http://h/g',
+      },
+      'http://h/p//q/..'        => { 'r' => 'http://h/p//r' },
+      'http://h/a/../..//y'     => { 'z' => 'http://h/z' },
+    }.each { |base, map|
+      map.each { |rel, expected|
+        assert_equal(expected, URI.parse(base).merge(rel).to_s,
+                     "<#{base}> + #{rel.inspect}")
+      }
+    }
+  end
+
+  def test_merge_path_dot_dot_removal_is_linear
+    # Regression guard for the previous O(n^2) base-path ".." removal:
+    # merging a base full of "a/../" segments must scale linearly.
+    pre = ->(n) {URI.parse('http://example.com/' + 'a/../' * n)}
+    assert_linear_performance((1..5).map {|i| 10 ** i}, pre: pre) do |base|
+      assert_equal('http://example.com/x', base.merge('x').to_s)
+    end
+  end
+
   def test_merge_authority
     u = URI.parse('http://user:pass@example.com:8080')
     u0 = URI.parse('http://new.example.org/path')


### PR DESCRIPTION
`URI.join` and `URI#merge` degrade quadratically as the base path grows. Joining against a base built from repeated `a/../` takes several seconds once it reaches a few hundred thousand segments, because the RFC2396 Section 5.2 6a step scans with `Array#index` and deletes with `slice!` inside a loop.

I replaced that loop with a single left-to-right pass over the base path, matching the linear stack already used for the relative path. The output is unchanged for every input, including the case where a leading `..` discards the whole base path rather than being kept as the relative side would.

I verified this by diffing the new pass against the old implementation over exhaustive segment combinations and hundreds of thousands of random deep inputs, both on `merge_path` directly and end to end through `URI.join`. Every result was identical.
