### PR TITLE
Repair legacy FTP.new2 construction

### DIFF
--- a/lib/uri/ftp.rb
+++ b/lib/uri/ftp.rb
@@ -49,7 +49,7 @@ module URI
       # Do not use this method!  Not tested.  [Bug #7301]
       # This methods remains just for compatibility,
       # Keep it undocumented until the active maintainer is assigned.
-      typecode = nil if typecode.size == 0
+      typecode = nil if typecode&.empty?
       if typecode && !TYPECODE.include?(typecode)
         raise ArgumentError,
           "bad typecode is specified: #{typecode}"
@@ -57,8 +57,10 @@ module URI
 
       # do escape
 
+      userinfo = password.nil? ? user : "#{user}:#{password}"
+
       self.new('ftp',
-               [user, password],
+               userinfo,
                host, port, nil,
                typecode ? path + TYPECODE_PREFIX + typecode : path,
                nil, nil, nil, arg_check)


### PR DESCRIPTION
The retained legacy FTP.new2 entry point crashes with its default typecode because it calls size on nil, and passes Array userinfo into Generic construction. Accept the default safely and construct the expected userinfo String. Current suites pass 93 tests / 3,039 assertions on Ruby 4.0.6 and 3.2.11; focused default, user, password and typecode models pass. No repository tests were changed.