### PR TITLE
Handle String arguments in FTP merge

### DIFF
--- a/lib/uri/ftp.rb
+++ b/lib/uri/ftp.rb
@@ -212,9 +212,11 @@ module URI
     end
 
     def merge(oth) # :nodoc:
-      tmp = super(oth)
-      if self != tmp
-        tmp.set_typecode(oth.typecode)
+      rel = parser.__send__(:convert_to_uri, oth)
+      tmp = super(rel)
+      if tmp.is_a?(FTP) && self != tmp
+        tmp.set_typecode(rel.is_a?(FTP) ? rel.typecode : nil)
+        tmp = parser.parse(tmp.to_s) unless rel.is_a?(FTP)
       end
 
       return tmp


### PR DESCRIPTION
FTP#merge delegates String conversion to Generic but then calls typecode on the original String, so relative, absolute FTP and cross-scheme String merges fail. Convert once, preserve FTP typecodes where applicable and reparse explicit relative typecodes coherently. Current suites pass 93 tests / 3,039 assertions on Ruby 4.0.6 and 3.2.11; focused merge models pass. No repository tests were changed.