### PR TITLE
Preserve FTP query and fragment in destructive merges

### DIFF
--- a/lib/uri/ftp.rb
+++ b/lib/uri/ftp.rb
@@ -220,6 +220,16 @@ module URI
       return tmp
     end
 
+    def merge!(oth) # :nodoc:
+      tmp = merge(oth)
+      return if self == tmp && query == tmp.query && fragment == tmp.fragment
+
+      replace!(tmp)
+      self.query = tmp.query
+      self.fragment = tmp.fragment
+      self
+    end
+
     # Returns the path from an FTP URI.
     #
     # RFC 1738 specifically states that the path for an FTP URI does not


### PR DESCRIPTION
FTP equality and component replacement omit query and fragment, so merge! with a query-only or fragment-only reference returns nil and silently drops the change. Copy those two Generic components explicitly when the merge differs there. Current suites pass 93 tests / 3,039 assertions on Ruby 4.0.6 and 3.2.11; focused destructive merge and unchanged-return models pass. No repository tests were changed.