### PR TITLE
Keep LDAP fields synchronized with generic setters

### DIFF
--- a/lib/uri/ldap.rb
+++ b/lib/uri/ldap.rb
@@ -116,6 +116,18 @@ module URI
       parse_query
     end
 
+    def set_path(val)
+      super
+      parse_dn if val
+    end
+    protected :set_path
+
+    def query=(val)
+      result = super
+      parse_query
+      result
+    end
+
     # Private method to cleanup +dn+ from using the +path+ component attribute.
     def parse_dn
       raise InvalidURIError, 'bad LDAP URL' unless @path


### PR DESCRIPTION
LDAP inherits path= and query= from Generic, but changing either serializes the new value while leaving dn, attributes, scope, filter and extensions stale. Reparse derived state after setter changes while preserving host-only transitional nil construction. Current suites pass 93 tests / 3,039 assertions on Ruby 4.0.6 and 3.2.11; focused setter/serialization models pass. No repository tests were changed.