### PR TITLE
Refresh WHATWG encoding labels

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -677,8 +677,11 @@ module URI
 =end
   WEB_ENCODINGS_ = {
     "unicode-1-1-utf-8"=>"utf-8",
+    "unicode11utf8"=>"utf-8",
+    "unicode20utf8"=>"utf-8",
     "utf-8"=>"utf-8",
     "utf8"=>"utf-8",
+    "x-unicode20utf8"=>"utf-8",
     "866"=>"ibm866",
     "cp866"=>"ibm866",
     "csibm866"=>"ibm866",
@@ -879,6 +882,12 @@ module URI
     "ksc_5601"=>"euc-kr",
     "windows-949"=>"euc-kr",
     "utf-16be"=>"utf-16be",
+    "unicodefffe"=>"utf-16be",
+    "csunicode"=>"utf-16le",
+    "iso-10646-ucs-2"=>"utf-16le",
+    "ucs-2"=>"utf-16le",
+    "unicode"=>"utf-16le",
+    "unicodefeff"=>"utf-16le",
     "utf-16"=>"utf-16le",
     "utf-16le"=>"utf-16le",
   } # :nodoc:


### PR DESCRIPTION
The generated WEB_ENCODINGS_ table has 205 entries while the current WHATWG registry has 214. Regenerate the table to add the nine missing UTF-8/UTF-16 aliases, with zero missing or extra labels afterward. Current suites pass 93 tests / 3,039 assertions on Ruby 4.0.6 and 3.2.11; regeneration, lookup and package checks pass. No repository tests were changed.